### PR TITLE
Add PHP/Laravel client library for Queen MQ

### DIFF
--- a/client-laravel/.gitignore
+++ b/client-laravel/.gitignore
@@ -1,0 +1,4 @@
+/vendor/
+composer.lock
+.phpunit.result.cache
+.phpunit.cache/

--- a/client-laravel/README.md
+++ b/client-laravel/README.md
@@ -1,0 +1,460 @@
+# Queen MQ - PHP/Laravel Client
+
+PHP client library for [Queen MQ](https://github.com/smartpricing/queen) with optional Laravel integration.
+
+Works standalone with any PHP 8.1+ project. Laravel extras (service provider, facade, artisan command) are auto-discovered.
+
+## Installation
+
+```bash
+composer require smartpricing/queen-mq
+```
+
+### Laravel Setup
+
+Publish the config file:
+
+```bash
+php artisan vendor:publish --tag=queen-config
+```
+
+Set your environment variables:
+
+```env
+QUEEN_URL=http://localhost:6632
+QUEEN_BEARER_TOKEN=your-token
+```
+
+## Usage
+
+### Standalone (without Laravel)
+
+```php
+use Queen\Queen;
+
+// Single server
+$queen = new Queen('http://localhost:6632');
+
+// Multiple servers with config
+$queen = new Queen([
+    'urls' => ['http://server1:6632', 'http://server2:6632'],
+    'loadBalancingStrategy' => 'affinity',
+    'bearerToken' => 'my-token',
+]);
+```
+
+### Laravel Facade
+
+```php
+use Queen\Laravel\QueenFacade as Queen;
+
+Queen::queue('orders')->push([['data' => ['test' => true]]])->execute();
+```
+
+## Queue Operations
+
+### Create a Queue
+
+```php
+$queen->queue('orders')
+    ->config(['leaseTime' => 300, 'retryLimit' => 3])
+    ->create()
+    ->execute();
+```
+
+### Delete a Queue
+
+```php
+$queen->queue('orders')->delete()->execute();
+```
+
+### Push Messages
+
+```php
+// Simple push
+$queen->queue('orders')
+    ->partition('user-123')
+    ->push([
+        ['data' => ['orderId' => 1, 'amount' => 100]],
+        ['data' => ['orderId' => 2, 'amount' => 200]],
+    ])
+    ->execute();
+
+// Push with callbacks
+$queen->queue('orders')
+    ->push([['data' => ['orderId' => 1]]])
+    ->onSuccess(function ($items) {
+        echo "Pushed " . count($items) . " messages\n";
+    })
+    ->onError(function ($items, $error) {
+        echo "Push failed: " . $error->getMessage() . "\n";
+    })
+    ->onDuplicate(function ($items, $error) {
+        echo "Duplicates detected\n";
+    })
+    ->execute();
+```
+
+### Buffered Push
+
+```php
+// Messages are accumulated and flushed when count or time threshold is reached
+$queen->queue('orders')
+    ->buffer(['messageCount' => 100, 'timeMillis' => 1000])
+    ->push([['data' => ['orderId' => 1]]])
+    ->execute();
+
+// Manually flush
+$queen->queue('orders')->flushBuffer();
+$queen->flushAllBuffers();
+```
+
+### Pop Messages
+
+```php
+// Pop a single message
+$messages = $queen->queue('orders')->pop();
+
+// Pop a batch with long polling
+$messages = $queen->queue('orders')
+    ->batch(10)
+    ->wait(true)
+    ->pop();
+
+// Pop from a specific partition
+$messages = $queen->queue('orders')
+    ->partition('user-123')
+    ->pop();
+```
+
+## Consuming Messages
+
+### High-Level Consumer (recommended)
+
+Inspired by [php-rdkafka](https://github.com/arnaud-lb/php-rdkafka)'s `KafkaConsumer`:
+
+```php
+$consumer = $queen->queue('orders')
+    ->group('processors')
+    ->batch(1)
+    ->autoAck(false)
+    ->getConsumer();
+
+$consumer->subscribe();
+
+while (!$consumer->isClosed()) {
+    $message = $consumer->consume(1000); // timeout in ms
+
+    if ($message === null) {
+        continue; // no message within timeout
+    }
+
+    // Process the message
+    processOrder($message['payload']);
+
+    // Acknowledge
+    $consumer->ack($message);
+}
+
+$consumer->close();
+```
+
+#### Batch consuming
+
+```php
+$consumer = $queen->queue('orders')
+    ->group('processors')
+    ->getConsumer();
+
+$consumer->subscribe();
+
+while (!$consumer->isClosed()) {
+    $messages = $consumer->consumeBatch(1000, 10); // timeout, max messages
+
+    if (empty($messages)) {
+        continue;
+    }
+
+    foreach ($messages as $msg) {
+        processOrder($msg['payload']);
+    }
+
+    $consumer->ack($messages);
+}
+
+$consumer->close();
+```
+
+#### Consumer methods
+
+| Method | Description |
+|--------|-------------|
+| `subscribe()` | Start the consumer (must call before consume) |
+| `consume(int $timeoutMs)` | Get one message or `null` |
+| `consumeBatch(int $timeoutMs, int $max)` | Get up to `$max` messages |
+| `ack(array $message)` | Acknowledge message(s) |
+| `nack(array $message)` | Negative-acknowledge (mark failed) |
+| `renewLease(array\|string $msg)` | Extend message lease |
+| `isClosed()` | Check if consumer was stopped |
+| `close()` | Stop the consumer |
+
+### Callback-Based Consumer
+
+```php
+$queen->queue('orders')
+    ->group('processors')
+    ->batch(10)
+    ->autoAck(true)
+    ->consume(function (array $messages) {
+        foreach ($messages as $msg) {
+            processOrder($msg['payload']);
+        }
+    })
+    ->execute();
+```
+
+### Consumer with Callbacks
+
+```php
+$queen->queue('orders')
+    ->group('processors')
+    ->each()
+    ->consume(function (array $message) {
+        processOrder($message['payload']);
+    })
+    ->onSuccess(function ($message) {
+        echo "Processed: {$message['transactionId']}\n";
+    })
+    ->onError(function ($message, $error) {
+        echo "Failed: {$error->getMessage()}\n";
+    })
+    ->execute();
+```
+
+## Transactions
+
+Atomic ack + push operations:
+
+```php
+$queen->transaction()
+    ->ack($messages)
+    ->queue('notifications')->partition('user-123')->push([
+        ['data' => ['notify' => true]],
+    ])
+    ->queue('audit-log')->push([
+        ['data' => ['action' => 'order-processed']],
+    ])
+    ->commit();
+```
+
+## Direct ACK
+
+```php
+// Single ack
+$queen->ack($message);
+
+// Batch ack
+$queen->ack($messages);
+
+// Nack (mark as failed)
+$queen->ack($message, false);
+
+// With consumer group context
+$queen->ack($message, true, ['group' => 'processors']);
+```
+
+## Lease Renewal
+
+```php
+// Renew a single message
+$queen->renew($message);
+
+// Renew by lease ID
+$queen->renew('lease-id-string');
+
+// Renew multiple
+$queen->renew($messages);
+```
+
+## Dead Letter Queue
+
+```php
+$result = $queen->queue('orders')
+    ->dlq('processors')
+    ->limit(50)
+    ->offset(0)
+    ->from('2024-01-01T00:00:00Z')
+    ->to('2024-12-31T23:59:59Z')
+    ->get();
+
+// $result = ['messages' => [...], 'total' => 123]
+```
+
+## Admin API
+
+```php
+$admin = $queen->admin();
+
+// Health
+$admin->health();
+
+// Resources
+$admin->getOverview();
+$admin->listQueues();
+$admin->getQueue('orders');
+$admin->getPartitions(['queue' => 'orders']);
+
+// Messages
+$admin->listMessages(['queue' => 'orders', 'status' => 'pending']);
+$admin->getMessage($partitionId, $transactionId);
+$admin->deleteMessage($partitionId, $transactionId);
+$admin->retryMessage($partitionId, $transactionId);
+$admin->moveMessageToDLQ($partitionId, $transactionId);
+
+// Consumer groups
+$admin->listConsumerGroups();
+$admin->getConsumerGroup('processors');
+$admin->getLaggingConsumers(60);
+$admin->seekConsumerGroup('processors', 'orders', ['timestamp' => '2024-01-01T00:00:00Z']);
+
+// System
+$admin->getMaintenanceMode();
+$admin->setMaintenanceMode(true);
+$admin->getSystemMetrics();
+$admin->getPostgresStats();
+```
+
+## Namespace/Task Wildcards
+
+```php
+// Pop from all queues in a namespace
+$messages = $queen->queue()
+    ->namespace('billing')
+    ->task('invoices')
+    ->batch(10)
+    ->pop();
+
+// Consume from namespace/task
+$consumer = $queen->queue()
+    ->namespace('billing')
+    ->group('invoice-processors')
+    ->getConsumer();
+```
+
+## Tracing
+
+Messages received from consumers include a `trace` callable:
+
+```php
+$consumer = $queen->queue('orders')->group('processors')->getConsumer();
+$consumer->subscribe();
+
+while (!$consumer->isClosed()) {
+    $message = $consumer->consume(1000);
+    if ($message === null) continue;
+
+    // Record a trace event
+    $trace = $message['trace'];
+    $trace([
+        'traceName' => ['tenant-acme', 'order-processing'],
+        'eventType' => 'info',
+        'data' => ['step' => 'started', 'orderId' => $message['payload']['orderId']],
+    ]);
+
+    processOrder($message['payload']);
+
+    $trace([
+        'data' => ['step' => 'completed'],
+    ]);
+
+    $consumer->ack($message);
+}
+```
+
+## Laravel Artisan Command
+
+```bash
+# Basic consumption
+php artisan queen:consume orders App\\Handlers\\OrderHandler --group=processors --auto-ack
+
+# With options
+php artisan queen:consume orders App\\Handlers\\OrderHandler \
+    --group=processors \
+    --batch=10 \
+    --auto-ack \
+    --timeout=30000 \
+    --limit=1000
+
+# Subscription mode
+php artisan queen:consume events App\\Handlers\\EventHandler \
+    --group=watchers \
+    --subscription-mode=all \
+    --subscription-from=2024-01-01T00:00:00Z
+```
+
+Handler class:
+
+```php
+namespace App\Handlers;
+
+class OrderHandler
+{
+    public function handle(array $messageOrMessages): void
+    {
+        // Process single message or batch
+    }
+}
+```
+
+## Configuration
+
+### Standalone
+
+```php
+$queen = new Queen([
+    'urls' => ['http://server1:6632', 'http://server2:6632'],
+    'loadBalancingStrategy' => 'affinity',  // 'round-robin', 'session', or 'affinity'
+    'bearerToken' => 'my-token',
+    'timeoutMillis' => 30000,
+    'retryAttempts' => 3,
+    'retryDelayMillis' => 1000,
+    'affinityHashRing' => 128,
+    'enableFailover' => true,
+    'healthRetryAfterMillis' => 5000,
+    'headers' => ['X-Custom' => 'value'],
+]);
+```
+
+### Laravel (`config/queen.php`)
+
+```php
+return [
+    'url' => env('QUEEN_URL', 'http://localhost:6632'),
+    'urls' => env('QUEEN_URLS') ? explode(',', env('QUEEN_URLS')) : null,
+    'bearer_token' => env('QUEEN_BEARER_TOKEN'),
+    'timeout' => env('QUEEN_TIMEOUT', 30000),
+    'retry_attempts' => env('QUEEN_RETRY_ATTEMPTS', 3),
+    'load_balancing_strategy' => env('QUEEN_LB_STRATEGY', 'affinity'),
+    'headers' => [],
+];
+```
+
+## Graceful Shutdown
+
+The high-level consumer handles SIGINT/SIGTERM automatically:
+
+```php
+$consumer = $queen->queue('orders')->group('processors')->getConsumer();
+$consumer->subscribe();
+
+while (!$consumer->isClosed()) {
+    $message = $consumer->consume(1000);
+    if ($message === null) continue;
+    processOrder($message['payload']);
+    $consumer->ack($message);
+}
+// Ctrl+C sets isClosed() = true, loop exits cleanly
+
+$consumer->close();
+$queen->close(); // Flushes any remaining buffers
+```

--- a/client-laravel/composer.json
+++ b/client-laravel/composer.json
@@ -1,0 +1,37 @@
+{
+    "name": "smartpricing/queen-mq",
+    "description": "Queen MQ client library for PHP with optional Laravel integration",
+    "type": "library",
+    "license": "MIT",
+    "require": {
+        "php": "^8.3",
+        "guzzlehttp/guzzle": "^7.0",
+        "ramsey/uuid": "^4.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.0|^12.0",
+        "orchestra/testbench": "^9.0|^10.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Queen\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Queen\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Queen\\Laravel\\QueenServiceProvider"
+            ],
+            "aliases": {
+                "Queen": "Queen\\Laravel\\QueenFacade"
+            }
+        }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
+}

--- a/client-laravel/config/queen.php
+++ b/client-laravel/config/queen.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'url' => env('QUEEN_URL', 'http://localhost:6632'),
+    'urls' => env('QUEEN_URLS') ? explode(',', env('QUEEN_URLS')) : null,
+    'bearer_token' => env('QUEEN_BEARER_TOKEN'),
+    'timeout' => env('QUEEN_TIMEOUT', 30000),
+    'retry_attempts' => env('QUEEN_RETRY_ATTEMPTS', 3),
+    'retry_delay' => env('QUEEN_RETRY_DELAY', 1000),
+    'load_balancing_strategy' => env('QUEEN_LB_STRATEGY', 'affinity'),
+    'enable_failover' => env('QUEEN_ENABLE_FAILOVER', true),
+    'affinity_hash_ring' => env('QUEEN_AFFINITY_HASH_RING', 150),
+    'health_retry_after' => env('QUEEN_HEALTH_RETRY_AFTER', 30000),
+    'headers' => [],
+];

--- a/client-laravel/phpunit.xml
+++ b/client-laravel/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache">
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/client-laravel/src/Admin.php
+++ b/client-laravel/src/Admin.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Queen;
+
+use Queen\Http\HttpClient;
+
+class Admin
+{
+    private HttpClient $httpClient;
+
+    public function __construct(HttpClient $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    // ===========================
+    // Resources API
+    // ===========================
+
+    public function getOverview(): mixed
+    {
+        return $this->httpClient->get('/api/v1/resources/overview');
+    }
+
+    public function getNamespaces(): mixed
+    {
+        return $this->httpClient->get('/api/v1/resources/namespaces');
+    }
+
+    public function getTasks(): mixed
+    {
+        return $this->httpClient->get('/api/v1/resources/tasks');
+    }
+
+    // ===========================
+    // Queues API
+    // ===========================
+
+    public function listQueues(array $params = []): mixed
+    {
+        return $this->httpClient->get('/api/v1/resources/queues' . $this->buildQueryString($params));
+    }
+
+    public function getQueue(string $name): mixed
+    {
+        return $this->httpClient->get('/api/v1/resources/queues/' . urlencode($name));
+    }
+
+    public function clearQueue(string $name, ?string $partition = null): mixed
+    {
+        $query = $partition !== null ? '?partition=' . urlencode($partition) : '';
+        return $this->httpClient->delete('/api/v1/queues/' . urlencode($name) . '/clear' . $query);
+    }
+
+    public function getPartitions(array $params = []): mixed
+    {
+        return $this->httpClient->get('/api/v1/resources/partitions' . $this->buildQueryString($params));
+    }
+
+    // ===========================
+    // Messages API
+    // ===========================
+
+    public function listMessages(array $params = []): mixed
+    {
+        return $this->httpClient->get('/api/v1/messages' . $this->buildQueryString($params));
+    }
+
+    public function getMessage(string $partitionId, string $transactionId): mixed
+    {
+        return $this->httpClient->get("/api/v1/messages/{$partitionId}/{$transactionId}");
+    }
+
+    public function deleteMessage(string $partitionId, string $transactionId): mixed
+    {
+        return $this->httpClient->delete("/api/v1/messages/{$partitionId}/{$transactionId}");
+    }
+
+    public function retryMessage(string $partitionId, string $transactionId): mixed
+    {
+        return $this->httpClient->post("/api/v1/messages/{$partitionId}/{$transactionId}/retry", []);
+    }
+
+    public function moveMessageToDLQ(string $partitionId, string $transactionId): mixed
+    {
+        return $this->httpClient->post("/api/v1/messages/{$partitionId}/{$transactionId}/dlq", []);
+    }
+
+    // ===========================
+    // Traces API
+    // ===========================
+
+    public function getTracesByName(string $traceName, array $params = []): mixed
+    {
+        return $this->httpClient->get('/api/v1/traces/by-name/' . urlencode($traceName) . $this->buildQueryString($params));
+    }
+
+    public function getTraceNames(array $params = []): mixed
+    {
+        return $this->httpClient->get('/api/v1/traces/names' . $this->buildQueryString($params));
+    }
+
+    public function getTracesForMessage(string $partitionId, string $transactionId): mixed
+    {
+        return $this->httpClient->get("/api/v1/traces/{$partitionId}/{$transactionId}");
+    }
+
+    // ===========================
+    // Analytics/Status API
+    // ===========================
+
+    public function getStatus(array $params = []): mixed
+    {
+        return $this->httpClient->get('/api/v1/status' . $this->buildQueryString($params));
+    }
+
+    public function getQueueStats(array $params = []): mixed
+    {
+        return $this->httpClient->get('/api/v1/status/queues' . $this->buildQueryString($params));
+    }
+
+    public function getQueueDetail(string $name, array $params = []): mixed
+    {
+        return $this->httpClient->get('/api/v1/status/queues/' . urlencode($name) . $this->buildQueryString($params));
+    }
+
+    public function getAnalytics(array $params = []): mixed
+    {
+        return $this->httpClient->get('/api/v1/status/analytics' . $this->buildQueryString($params));
+    }
+
+    // ===========================
+    // Consumer Groups API
+    // ===========================
+
+    public function listConsumerGroups(): mixed
+    {
+        return $this->httpClient->get('/api/v1/consumer-groups');
+    }
+
+    public function refreshConsumerStats(): mixed
+    {
+        return $this->httpClient->post('/api/v1/stats/refresh', []);
+    }
+
+    public function getConsumerGroup(string $name): mixed
+    {
+        return $this->httpClient->get('/api/v1/consumer-groups/' . urlencode($name));
+    }
+
+    public function getLaggingConsumers(int $minLagSeconds = 60): mixed
+    {
+        return $this->httpClient->get("/api/v1/consumer-groups/lagging?minLagSeconds={$minLagSeconds}");
+    }
+
+    public function deleteConsumerGroupForQueue(string $consumerGroup, string $queueName, bool $deleteMetadata = true): mixed
+    {
+        $dm = $deleteMetadata ? 'true' : 'false';
+        return $this->httpClient->delete('/api/v1/consumer-groups/' . urlencode($consumerGroup) . '/queues/' . urlencode($queueName) . "?deleteMetadata={$dm}");
+    }
+
+    public function seekConsumerGroup(string $consumerGroup, string $queueName, array $options = []): mixed
+    {
+        return $this->httpClient->post('/api/v1/consumer-groups/' . urlencode($consumerGroup) . '/queues/' . urlencode($queueName) . '/seek', $options);
+    }
+
+    // ===========================
+    // System API
+    // ===========================
+
+    public function health(): mixed
+    {
+        return $this->httpClient->get('/health');
+    }
+
+    public function metrics(): mixed
+    {
+        return $this->httpClient->get('/metrics');
+    }
+
+    public function getMaintenanceMode(): mixed
+    {
+        return $this->httpClient->get('/api/v1/system/maintenance');
+    }
+
+    public function setMaintenanceMode(bool $enabled): mixed
+    {
+        return $this->httpClient->post('/api/v1/system/maintenance', ['enabled' => $enabled]);
+    }
+
+    public function getPopMaintenanceMode(): mixed
+    {
+        return $this->httpClient->get('/api/v1/system/maintenance/pop');
+    }
+
+    public function setPopMaintenanceMode(bool $enabled): mixed
+    {
+        return $this->httpClient->post('/api/v1/system/maintenance/pop', ['enabled' => $enabled]);
+    }
+
+    public function getSystemMetrics(array $params = []): mixed
+    {
+        return $this->httpClient->get('/api/v1/analytics/system-metrics' . $this->buildQueryString($params));
+    }
+
+    public function getWorkerMetrics(array $params = []): mixed
+    {
+        return $this->httpClient->get('/api/v1/analytics/worker-metrics' . $this->buildQueryString($params));
+    }
+
+    public function getPostgresStats(): mixed
+    {
+        return $this->httpClient->get('/api/v1/analytics/postgres-stats');
+    }
+
+    // ===========================
+    // Helpers
+    // ===========================
+
+    private function buildQueryString(array $params): string
+    {
+        $filtered = array_filter($params, fn($v) => $v !== null);
+        if (empty($filtered)) {
+            return '';
+        }
+        return '?' . http_build_query($filtered);
+    }
+}

--- a/client-laravel/src/Buffer/BufferManager.php
+++ b/client-laravel/src/Buffer/BufferManager.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Queen\Buffer;
+
+use Queen\Http\HttpClient;
+use Queen\Support\Defaults;
+
+class BufferManager
+{
+    private HttpClient $httpClient;
+    /** @var array<string, MessageBuffer> */
+    private array $buffers = [];
+    private int $flushCount = 0;
+
+    public function __construct(HttpClient $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    public function addMessage(string $queueAddress, array $formattedMessage, array $bufferOptions): void
+    {
+        $options = array_merge(Defaults::BUFFER_DEFAULTS, $bufferOptions);
+
+        if (!isset($this->buffers[$queueAddress])) {
+            $this->buffers[$queueAddress] = new MessageBuffer(
+                $queueAddress,
+                $options,
+                fn(string $addr) => $this->doFlush($addr)
+            );
+        }
+
+        $buffer = $this->buffers[$queueAddress];
+
+        // Check time-based trigger before adding (since PHP has no background timers)
+        $buffer->checkTimeTrigger();
+
+        $buffer->add($formattedMessage);
+    }
+
+    private function doFlush(string $queueAddress): void
+    {
+        $buffer = $this->buffers[$queueAddress] ?? null;
+        if ($buffer === null || $buffer->getMessageCount() === 0) {
+            return;
+        }
+
+        $buffer->setFlushing(true);
+
+        $messages = $buffer->extractMessages();
+        if (empty($messages)) {
+            $buffer->setFlushing(false);
+            return;
+        }
+
+        try {
+            $this->httpClient->post('/api/v1/push', ['items' => $messages]);
+            $this->flushCount++;
+            unset($this->buffers[$queueAddress]);
+        } catch (\Throwable $error) {
+            $buffer->restoreMessages($messages);
+            throw $error;
+        }
+    }
+
+    public function flushBuffer(string $queueAddress): void
+    {
+        $buffer = $this->buffers[$queueAddress] ?? null;
+        if ($buffer === null) {
+            return;
+        }
+
+        $batchSize = $buffer->getOptions()['messageCount'];
+
+        while ($buffer->getMessageCount() > 0) {
+            $buffer->setFlushing(true);
+            $messages = $buffer->extractMessages($batchSize);
+            if (empty($messages)) {
+                break;
+            }
+            try {
+                $this->httpClient->post('/api/v1/push', ['items' => $messages]);
+                $this->flushCount++;
+            } catch (\Throwable $error) {
+                $buffer->restoreMessages($messages);
+                throw $error;
+            }
+        }
+
+        unset($this->buffers[$queueAddress]);
+    }
+
+    /**
+     * Flush all buffers concurrently using async HTTP.
+     * Each buffer's batches are extracted up front, then all sent in parallel.
+     */
+    public function flushAllBuffers(): void
+    {
+        $addresses = array_keys($this->buffers);
+
+        if (empty($addresses)) {
+            return;
+        }
+
+        // Collect all batches from all buffers
+        $batches = []; // [[messages, address], ...]
+        foreach ($addresses as $address) {
+            $buffer = $this->buffers[$address] ?? null;
+            if ($buffer === null || $buffer->getMessageCount() === 0) {
+                continue;
+            }
+
+            $batchSize = $buffer->getOptions()['messageCount'];
+            $buffer->setFlushing(true);
+
+            while ($buffer->getMessageCount() > 0) {
+                $messages = $buffer->extractMessages($batchSize);
+                if (!empty($messages)) {
+                    $batches[] = [$messages, $address];
+                }
+            }
+        }
+
+        if (empty($batches)) {
+            foreach ($addresses as $address) {
+                unset($this->buffers[$address]);
+            }
+            return;
+        }
+
+        // Send all batches concurrently
+        $promises = [];
+        foreach ($batches as $i => [$messages, $address]) {
+            $promises[$i] = $this->httpClient->postAsync('/api/v1/push', ['items' => $messages]);
+        }
+
+        $results = HttpClient::settleAll($promises);
+
+        // Check for failures — restore messages for failed batches
+        $errors = [];
+        foreach ($results as $i => $outcome) {
+            if ($outcome['state'] === 'fulfilled') {
+                $this->flushCount++;
+            } else {
+                [$failedMessages, $failedAddress] = $batches[$i];
+                // Re-create buffer if needed and restore messages
+                if (!isset($this->buffers[$failedAddress])) {
+                    $this->buffers[$failedAddress] = new MessageBuffer(
+                        $failedAddress,
+                        Defaults::BUFFER_DEFAULTS,
+                        fn(string $addr) => $this->doFlush($addr)
+                    );
+                }
+                $this->buffers[$failedAddress]->restoreMessages($failedMessages);
+                $errors[] = $outcome['reason'];
+            }
+        }
+
+        // Clean up only successful buffers
+        foreach ($addresses as $address) {
+            $buffer = $this->buffers[$address] ?? null;
+            if ($buffer !== null && $buffer->getMessageCount() === 0) {
+                unset($this->buffers[$address]);
+            }
+        }
+
+        // Throw first error if any failed
+        if (!empty($errors)) {
+            throw $errors[0];
+        }
+    }
+
+    public function getStats(): array
+    {
+        $totalBufferedMessages = 0;
+        $oldestBufferAge = 0.0;
+
+        foreach ($this->buffers as $buffer) {
+            $totalBufferedMessages += $buffer->getMessageCount();
+            $age = $buffer->getFirstMessageAge();
+            $oldestBufferAge = max($oldestBufferAge, $age);
+        }
+
+        return [
+            'activeBuffers' => count($this->buffers),
+            'totalBufferedMessages' => $totalBufferedMessages,
+            'oldestBufferAge' => $oldestBufferAge,
+            'flushesPerformed' => $this->flushCount,
+        ];
+    }
+
+    public function cleanup(): void
+    {
+        foreach ($this->buffers as $buffer) {
+            $buffer->cleanup();
+        }
+        $this->buffers = [];
+    }
+}

--- a/client-laravel/src/Buffer/MessageBuffer.php
+++ b/client-laravel/src/Buffer/MessageBuffer.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Queen\Buffer;
+
+class MessageBuffer
+{
+    private string $queueAddress;
+    private array $messages = [];
+    private array $options;
+    private \Closure $flushCallback;
+    private ?float $firstMessageTime = null;
+    private bool $flushing = false;
+
+    public function __construct(string $queueAddress, array $options, \Closure $flushCallback)
+    {
+        $this->queueAddress = $queueAddress;
+        $this->options = $options;
+        $this->flushCallback = $flushCallback;
+    }
+
+    public function add(array $formattedMessage): void
+    {
+        if (empty($this->messages)) {
+            $this->firstMessageTime = microtime(true);
+        }
+
+        $this->messages[] = $formattedMessage;
+
+        // Check if we should flush based on count
+        if (count($this->messages) >= $this->options['messageCount']) {
+            $this->triggerFlush();
+        }
+    }
+
+    /**
+     * Check time-based flush trigger. Call this periodically.
+     */
+    public function checkTimeTrigger(): void
+    {
+        if ($this->flushing || empty($this->messages) || $this->firstMessageTime === null) {
+            return;
+        }
+
+        $elapsedMs = (microtime(true) - $this->firstMessageTime) * 1000;
+        if ($elapsedMs >= $this->options['timeMillis']) {
+            $this->triggerFlush();
+        }
+    }
+
+    private function triggerFlush(): void
+    {
+        if ($this->flushing || empty($this->messages)) {
+            return;
+        }
+
+        $this->flushing = true;
+        ($this->flushCallback)($this->queueAddress);
+    }
+
+    public function extractMessages(?int $batchSize = null): array
+    {
+        if ($batchSize === null || $batchSize >= count($this->messages)) {
+            $messages = $this->messages;
+            $this->messages = [];
+            $this->firstMessageTime = null;
+            $this->flushing = false;
+            return $messages;
+        }
+
+        $messages = array_splice($this->messages, 0, $batchSize);
+
+        if (empty($this->messages)) {
+            $this->firstMessageTime = null;
+            $this->flushing = false;
+        }
+
+        return $messages;
+    }
+
+    /**
+     * Restore messages to the front of the buffer (used on flush failure).
+     */
+    public function restoreMessages(array $messages): void
+    {
+        array_unshift($this->messages, ...$messages);
+        if ($this->firstMessageTime === null && !empty($this->messages)) {
+            $this->firstMessageTime = microtime(true);
+        }
+        $this->flushing = false;
+    }
+
+    public function setFlushing(bool $value): void
+    {
+        $this->flushing = $value;
+    }
+
+    public function getMessageCount(): int
+    {
+        return count($this->messages);
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function getFirstMessageAge(): float
+    {
+        return $this->firstMessageTime !== null
+            ? (microtime(true) - $this->firstMessageTime) * 1000
+            : 0;
+    }
+
+    public function cleanup(): void
+    {
+        $this->messages = [];
+        $this->firstMessageTime = null;
+        $this->flushing = false;
+    }
+}

--- a/client-laravel/src/Builders/ConsumeBuilder.php
+++ b/client-laravel/src/Builders/ConsumeBuilder.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Queen\Builders;
+
+use Queen\Http\HttpClient;
+use Queen\Queen;
+use Queen\Consumer\ConsumerManager;
+
+class ConsumeBuilder
+{
+    private HttpClient $httpClient;
+    private Queen $queen;
+    private \Closure $handler;
+    private array $options;
+    private ?\Closure $onSuccessCallback = null;
+    private ?\Closure $onErrorCallback = null;
+
+    public function __construct(HttpClient $httpClient, Queen $queen, \Closure $handler, array $options)
+    {
+        $this->httpClient = $httpClient;
+        $this->queen = $queen;
+        $this->handler = $handler;
+        $this->options = $options;
+    }
+
+    public function onSuccess(\Closure $callback): static
+    {
+        $this->onSuccessCallback = $callback;
+        return $this;
+    }
+
+    public function onError(\Closure $callback): static
+    {
+        $this->onErrorCallback = $callback;
+        return $this;
+    }
+
+    public function execute(): void
+    {
+        $consumerManager = new ConsumerManager($this->httpClient, $this->queen);
+
+        $handler = $this->handler;
+        $onSuccess = $this->onSuccessCallback;
+        $onError = $this->onErrorCallback;
+
+        // Callbacks are observers — autoAck remains as configured.
+        // ConsumerManager handles ack/nack. The wrapper just adds
+        // onSuccess/onError notifications around the user handler.
+        $wrappedHandler = function (array|object $msgOrMsgs) use ($handler, $onSuccess, $onError): void {
+            try {
+                $handler($msgOrMsgs);
+
+                if ($onSuccess !== null) {
+                    $onSuccess($msgOrMsgs);
+                }
+            } catch (\Throwable $error) {
+                if ($onError !== null) {
+                    $onError($msgOrMsgs, $error);
+                    // Don't re-throw — onError handled it.
+                    // ConsumerManager's autoAck will NACK via its own catch.
+                    // We need to re-throw so ConsumerManager sees the failure.
+                }
+                throw $error;
+            }
+        };
+
+        $consumerManager->start($wrappedHandler, $this->options);
+    }
+}

--- a/client-laravel/src/Builders/DLQBuilder.php
+++ b/client-laravel/src/Builders/DLQBuilder.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Queen\Builders;
+
+use Queen\Http\HttpClient;
+
+class DLQBuilder
+{
+    private HttpClient $httpClient;
+    private string $queueName;
+    private ?string $consumerGroup;
+    private ?string $partition;
+    private int $queryLimit = 100;
+    private int $queryOffset = 0;
+    private ?string $fromTimestamp = null;
+    private ?string $toTimestamp = null;
+
+    public function __construct(HttpClient $httpClient, string $queueName, ?string $consumerGroup, ?string $partition)
+    {
+        $this->httpClient = $httpClient;
+        $this->queueName = $queueName;
+        $this->consumerGroup = $consumerGroup;
+        $this->partition = $partition !== 'Default' ? $partition : null;
+    }
+
+    public function limit(int $count): static
+    {
+        $this->queryLimit = max(1, $count);
+        return $this;
+    }
+
+    public function offset(int $count): static
+    {
+        $this->queryOffset = max(0, $count);
+        return $this;
+    }
+
+    public function from(string $timestamp): static
+    {
+        $this->fromTimestamp = $timestamp;
+        return $this;
+    }
+
+    public function to(string $timestamp): static
+    {
+        $this->toTimestamp = $timestamp;
+        return $this;
+    }
+
+    public function get(): array
+    {
+        $params = [
+            'queue' => $this->queueName,
+            'limit' => (string) $this->queryLimit,
+            'offset' => (string) $this->queryOffset,
+        ];
+
+        if ($this->consumerGroup !== null) {
+            $params['consumerGroup'] = $this->consumerGroup;
+        }
+
+        if ($this->partition !== null) {
+            $params['partition'] = $this->partition;
+        }
+
+        if ($this->fromTimestamp !== null) {
+            $params['from'] = $this->fromTimestamp;
+        }
+
+        if ($this->toTimestamp !== null) {
+            $params['to'] = $this->toTimestamp;
+        }
+
+        $query = http_build_query($params);
+        $result = $this->httpClient->get("/api/v1/dlq?{$query}");
+        return $result ?? ['messages' => [], 'total' => 0];
+    }
+}

--- a/client-laravel/src/Builders/OperationBuilder.php
+++ b/client-laravel/src/Builders/OperationBuilder.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Queen\Builders;
+
+use Queen\Http\HttpClient;
+
+class OperationBuilder
+{
+    private HttpClient $httpClient;
+    private string $method;
+    private string $path;
+    private ?array $body;
+    private ?\Closure $onSuccessCallback = null;
+    private ?\Closure $onErrorCallback = null;
+
+    public function __construct(HttpClient $httpClient, string $method, string $path, ?array $body)
+    {
+        $this->httpClient = $httpClient;
+        $this->method = $method;
+        $this->path = $path;
+        $this->body = $body;
+    }
+
+    public function onSuccess(\Closure $callback): static
+    {
+        $this->onSuccessCallback = $callback;
+        return $this;
+    }
+
+    public function onError(\Closure $callback): static
+    {
+        $this->onErrorCallback = $callback;
+        return $this;
+    }
+
+    public function execute(): mixed
+    {
+        try {
+            $result = match ($this->method) {
+                'GET' => $this->httpClient->get($this->path),
+                'POST' => $this->httpClient->post($this->path, $this->body),
+                'PUT' => $this->httpClient->put($this->path, $this->body),
+                'DELETE' => $this->httpClient->delete($this->path),
+            };
+
+            if (is_array($result) && isset($result['error'])) {
+                $error = new \RuntimeException($result['error']);
+                if ($this->onErrorCallback !== null) {
+                    ($this->onErrorCallback)($error);
+                    return ['success' => false, 'error' => $result['error']];
+                }
+                throw $error;
+            }
+
+            if ($this->onSuccessCallback !== null) {
+                ($this->onSuccessCallback)($result);
+            }
+
+            return $result;
+        } catch (\Throwable $error) {
+            if ($this->onErrorCallback !== null) {
+                ($this->onErrorCallback)($error);
+                return ['success' => false, 'error' => $error->getMessage()];
+            }
+            throw $error;
+        }
+    }
+}

--- a/client-laravel/src/Builders/PushBuilder.php
+++ b/client-laravel/src/Builders/PushBuilder.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Queen\Builders;
+
+use Queen\Http\HttpClient;
+use Queen\Buffer\BufferManager;
+
+class PushBuilder
+{
+    private HttpClient $httpClient;
+    private BufferManager $bufferManager;
+    private string $queueName;
+    private string $partition;
+    private array $formattedItems;
+    private ?array $bufferOptions;
+    private ?\Closure $onSuccessCallback = null;
+    private ?\Closure $onErrorCallback = null;
+    private ?\Closure $onDuplicateCallback = null;
+
+    public function __construct(
+        HttpClient $httpClient,
+        BufferManager $bufferManager,
+        string $queueName,
+        string $partition,
+        array $formattedItems,
+        ?array $bufferOptions
+    ) {
+        $this->httpClient = $httpClient;
+        $this->bufferManager = $bufferManager;
+        $this->queueName = $queueName;
+        $this->partition = $partition;
+        $this->formattedItems = $formattedItems;
+        $this->bufferOptions = $bufferOptions;
+    }
+
+    public function onSuccess(\Closure $callback): static
+    {
+        $this->onSuccessCallback = $callback;
+        return $this;
+    }
+
+    public function onError(\Closure $callback): static
+    {
+        $this->onErrorCallback = $callback;
+        return $this;
+    }
+
+    public function onDuplicate(\Closure $callback): static
+    {
+        $this->onDuplicateCallback = $callback;
+        return $this;
+    }
+
+    public function execute(): mixed
+    {
+        // Client-side buffering
+        if ($this->bufferOptions !== null) {
+            $queueAddress = "{$this->queueName}/{$this->partition}";
+            foreach ($this->formattedItems as $item) {
+                $this->bufferManager->addMessage($queueAddress, $item, $this->bufferOptions);
+            }
+
+            $result = ['buffered' => true, 'count' => count($this->formattedItems)];
+
+            if ($this->onSuccessCallback !== null) {
+                ($this->onSuccessCallback)($this->formattedItems);
+            }
+
+            return $result;
+        }
+
+        // Immediate push
+        try {
+            $results = $this->httpClient->post('/api/v1/push', ['items' => $this->formattedItems]);
+
+            if (is_array($results) && !isset($results[0]) && isset($results['error'])) {
+                // Non-array error response
+                $error = new \RuntimeException($results['error']);
+                if ($this->onErrorCallback !== null) {
+                    ($this->onErrorCallback)($this->formattedItems, $error);
+                    return $results;
+                }
+                throw $error;
+            }
+
+            if (is_array($results) && isset($results[0])) {
+                // Array of per-item results
+                $successful = [];
+                $duplicates = [];
+                $failed = [];
+
+                foreach ($results as $i => $result) {
+                    $originalItem = $this->formattedItems[$i] ?? null;
+
+                    if (($result['status'] ?? null) === 'duplicate') {
+                        $duplicates[] = array_merge($originalItem ?? [], ['result' => $result]);
+                    } elseif (($result['status'] ?? null) === 'failed') {
+                        $failed[] = array_merge($originalItem ?? [], ['result' => $result, 'error' => $result['error'] ?? null]);
+                    } elseif (($result['status'] ?? null) === 'queued') {
+                        $successful[] = array_merge($originalItem ?? [], ['result' => $result]);
+                    }
+                }
+
+                if (!empty($duplicates) && $this->onDuplicateCallback !== null) {
+                    ($this->onDuplicateCallback)($duplicates, new \RuntimeException('Duplicate transaction IDs detected'));
+                }
+
+                if (!empty($failed) && $this->onErrorCallback !== null) {
+                    ($this->onErrorCallback)($failed, new \RuntimeException($failed[0]['error'] ?? 'Push failed'));
+                }
+
+                if (!empty($successful) && $this->onSuccessCallback !== null) {
+                    ($this->onSuccessCallback)($successful);
+                }
+
+                if (!empty($failed) && $this->onErrorCallback === null) {
+                    throw new \RuntimeException($failed[0]['error'] ?? 'Push failed');
+                }
+
+                return $results;
+            }
+
+            if ($this->onSuccessCallback !== null) {
+                ($this->onSuccessCallback)($this->formattedItems);
+            }
+
+            return $results;
+        } catch (\Throwable $error) {
+            if ($this->onErrorCallback !== null) {
+                ($this->onErrorCallback)($this->formattedItems, $error);
+                return null;
+            }
+            throw $error;
+        }
+    }
+}

--- a/client-laravel/src/Builders/QueueBuilder.php
+++ b/client-laravel/src/Builders/QueueBuilder.php
@@ -1,0 +1,402 @@
+<?php
+
+namespace Queen\Builders;
+
+use Queen\Queen;
+use Queen\Http\HttpClient;
+use Queen\Buffer\BufferManager;
+use Queen\Consumer\HighLevelConsumer;
+use Queen\Support\Defaults;
+use Queen\Support\Uuid;
+
+class QueueBuilder
+{
+    private Queen $queen;
+    private HttpClient $httpClient;
+    private BufferManager $bufferManager;
+    private ?string $queueName;
+    private string $partition = 'Default';
+    private ?string $namespace = null;
+    private ?string $task = null;
+    private ?string $group = null;
+    private array $config = [];
+
+    // Consume options
+    private int $consumeConcurrency;
+    private int $consumeBatch;
+    private ?int $consumeLimit;
+    private ?int $consumeIdleMillis;
+    private bool $consumeAutoAck;
+    private bool $consumeWait;
+    private int $consumeTimeoutMillis;
+    private bool $consumeRenewLease;
+    private ?int $consumeRenewLeaseIntervalMillis;
+    private ?string $consumeSubscriptionMode;
+    private ?string $consumeSubscriptionFrom;
+    private bool $consumeEach = false;
+
+    // Buffer options
+    private ?array $bufferOptions = null;
+
+    public function __construct(Queen $queen, HttpClient $httpClient, BufferManager $bufferManager, ?string $queueName = null)
+    {
+        $this->queen = $queen;
+        $this->httpClient = $httpClient;
+        $this->bufferManager = $bufferManager;
+        $this->queueName = $queueName;
+
+        // Initialize from consume defaults
+        $d = Defaults::CONSUME_DEFAULTS;
+        $this->consumeConcurrency = $d['concurrency'];
+        $this->consumeBatch = $d['batch'];
+        $this->consumeLimit = $d['limit'];
+        $this->consumeIdleMillis = $d['idleMillis'];
+        $this->consumeAutoAck = $d['autoAck'];
+        $this->consumeWait = $d['wait'];
+        $this->consumeTimeoutMillis = $d['timeoutMillis'];
+        $this->consumeRenewLease = $d['renewLease'];
+        $this->consumeRenewLeaseIntervalMillis = $d['renewLeaseIntervalMillis'];
+        $this->consumeSubscriptionMode = $d['subscriptionMode'];
+        $this->consumeSubscriptionFrom = $d['subscriptionFrom'];
+    }
+
+    // ===========================
+    // Affinity Key Generation
+    // ===========================
+
+    private function getAffinityKey(): ?string
+    {
+        if ($this->queueName !== null) {
+            $partition = $this->partition ?: '*';
+            $group = $this->group ?: '__QUEUE_MODE__';
+            return "{$this->queueName}:{$partition}:{$group}";
+        }
+
+        if ($this->namespace !== null || $this->task !== null) {
+            $ns = $this->namespace ?: '*';
+            $task = $this->task ?: '*';
+            $group = $this->group ?: '__QUEUE_MODE__';
+            return "{$ns}:{$task}:{$group}";
+        }
+
+        return null;
+    }
+
+    // ===========================
+    // Queue Configuration
+    // ===========================
+
+    public function namespace(string $name): static
+    {
+        $this->namespace = $name;
+        return $this;
+    }
+
+    public function task(string $name): static
+    {
+        $this->task = $name;
+        return $this;
+    }
+
+    public function config(array $options): static
+    {
+        $this->config = array_merge(Defaults::QUEUE_DEFAULTS, $options);
+        return $this;
+    }
+
+    public function create(): OperationBuilder
+    {
+        $fullConfig = !empty($this->config) ? $this->config : Defaults::QUEUE_DEFAULTS;
+
+        return new OperationBuilder($this->httpClient, 'POST', '/api/v1/configure', [
+            'queue' => $this->queueName,
+            'namespace' => $this->namespace,
+            'task' => $this->task,
+            'options' => $fullConfig,
+        ]);
+    }
+
+    public function delete(): OperationBuilder
+    {
+        if ($this->queueName === null) {
+            throw new \RuntimeException('Queue name is required for delete operation');
+        }
+
+        return new OperationBuilder(
+            $this->httpClient,
+            'DELETE',
+            '/api/v1/resources/queues/' . urlencode($this->queueName),
+            null
+        );
+    }
+
+    // ===========================
+    // Push Methods
+    // ===========================
+
+    public function partition(string $name): static
+    {
+        $this->partition = $name;
+        return $this;
+    }
+
+    public function buffer(array $options): static
+    {
+        $this->bufferOptions = $options;
+        return $this;
+    }
+
+    public function push(array $payload): PushBuilder
+    {
+        if ($this->queueName === null) {
+            throw new \RuntimeException('Queue name is required for push operation');
+        }
+
+        $items = isset($payload[0]) || empty($payload) ? $payload : [$payload];
+        $formattedItems = array_map(function (array $item) {
+            if (array_key_exists('data', $item)) {
+                $payloadValue = $item['data'];
+            } elseif (array_key_exists('payload', $item)) {
+                $payloadValue = $item['payload'];
+            } else {
+                $payloadValue = $item;
+            }
+
+            $result = [
+                'queue' => $this->queueName,
+                'partition' => $this->partition,
+                'payload' => $payloadValue,
+                'transactionId' => $item['transactionId'] ?? Uuid::v7(),
+            ];
+
+            if (isset($item['traceId'])) {
+                $result['traceId'] = $item['traceId'];
+            }
+
+            return $result;
+        }, $items);
+
+        return new PushBuilder(
+            $this->httpClient,
+            $this->bufferManager,
+            $this->queueName,
+            $this->partition,
+            $formattedItems,
+            $this->bufferOptions
+        );
+    }
+
+    // ===========================
+    // Consume Configuration
+    // ===========================
+
+    public function group(string $name): static
+    {
+        $this->group = $name;
+        return $this;
+    }
+
+    public function concurrency(int $count): static
+    {
+        $this->consumeConcurrency = max(1, $count);
+        return $this;
+    }
+
+    public function batch(int $size): static
+    {
+        $this->consumeBatch = max(1, $size);
+        return $this;
+    }
+
+    public function limit(int $count): static
+    {
+        $this->consumeLimit = $count;
+        return $this;
+    }
+
+    public function idleMillis(int $millis): static
+    {
+        $this->consumeIdleMillis = $millis;
+        return $this;
+    }
+
+    public function autoAck(bool $enabled): static
+    {
+        $this->consumeAutoAck = $enabled;
+        return $this;
+    }
+
+    public function wait(bool $enabled): static
+    {
+        $this->consumeWait = $enabled;
+        return $this;
+    }
+
+    public function timeoutMillis(int $millis): static
+    {
+        $this->consumeTimeoutMillis = $millis;
+        return $this;
+    }
+
+    public function renewLease(bool $enabled, ?int $intervalMillis = null): static
+    {
+        $this->consumeRenewLease = $enabled;
+        if ($intervalMillis !== null) {
+            $this->consumeRenewLeaseIntervalMillis = $intervalMillis;
+        }
+        return $this;
+    }
+
+    public function subscriptionMode(string $mode): static
+    {
+        $this->consumeSubscriptionMode = $mode;
+        return $this;
+    }
+
+    public function subscriptionFrom(string $from): static
+    {
+        $this->consumeSubscriptionFrom = $from;
+        return $this;
+    }
+
+    public function each(): static
+    {
+        $this->consumeEach = true;
+        return $this;
+    }
+
+    // ===========================
+    // Consume (callback-based)
+    // ===========================
+
+    public function consume(\Closure $handler): ConsumeBuilder
+    {
+        return new ConsumeBuilder($this->httpClient, $this->queen, $handler, $this->buildConsumeOptions());
+    }
+
+    // ===========================
+    // High-Level Consumer (rdkafka-style)
+    // ===========================
+
+    public function getConsumer(): HighLevelConsumer
+    {
+        return new HighLevelConsumer($this->httpClient, $this->queen, $this->buildConsumeOptions());
+    }
+
+    // ===========================
+    // Pop
+    // ===========================
+
+    public function pop(): array
+    {
+        $path = $this->buildPopPath();
+
+        // Pop uses POP_DEFAULTS for autoAck unless explicitly changed
+        $effectiveAutoAck = $this->consumeAutoAck !== Defaults::CONSUME_DEFAULTS['autoAck']
+            ? $this->consumeAutoAck
+            : Defaults::POP_DEFAULTS['autoAck'];
+
+        $params = [
+            'batch' => (string) $this->consumeBatch,
+            'wait' => $this->consumeWait ? 'true' : 'false',
+            'timeout' => (string) $this->consumeTimeoutMillis,
+        ];
+
+        if ($this->group !== null) {
+            $params['consumerGroup'] = $this->group;
+        }
+        if ($this->namespace !== null) {
+            $params['namespace'] = $this->namespace;
+        }
+        if ($this->task !== null) {
+            $params['task'] = $this->task;
+        }
+        if ($effectiveAutoAck) {
+            $params['autoAck'] = 'true';
+        }
+        if ($this->consumeSubscriptionMode !== null) {
+            $params['subscriptionMode'] = $this->consumeSubscriptionMode;
+        }
+        if ($this->consumeSubscriptionFrom !== null) {
+            $params['subscriptionFrom'] = $this->consumeSubscriptionFrom;
+        }
+
+        $query = http_build_query($params);
+        $affinityKey = $this->getAffinityKey();
+        $result = $this->httpClient->get("{$path}?{$query}", $this->consumeTimeoutMillis + 5000, $affinityKey);
+
+        if (!$result || !isset($result['messages'])) {
+            return [];
+        }
+
+        return array_filter($result['messages'], fn($msg) => $msg !== null);
+    }
+
+    // ===========================
+    // Buffer
+    // ===========================
+
+    public function flushBuffer(): void
+    {
+        if ($this->queueName === null) {
+            throw new \RuntimeException('Queue name is required for buffer flush');
+        }
+        $queueAddress = "{$this->queueName}/{$this->partition}";
+        $this->bufferManager->flushBuffer($queueAddress);
+    }
+
+    // ===========================
+    // DLQ
+    // ===========================
+
+    public function dlq(?string $consumerGroup = null): DLQBuilder
+    {
+        if ($this->queueName === null) {
+            throw new \RuntimeException('Queue name is required for DLQ operations');
+        }
+        return new DLQBuilder($this->httpClient, $this->queueName, $consumerGroup, $this->partition);
+    }
+
+    // ===========================
+    // Private helpers
+    // ===========================
+
+    private function buildConsumeOptions(): array
+    {
+        return [
+            'queue' => $this->queueName,
+            'partition' => $this->partition !== 'Default' ? $this->partition : null,
+            'namespace' => $this->namespace,
+            'task' => $this->task,
+            'group' => $this->group,
+            'concurrency' => $this->consumeConcurrency,
+            'batch' => $this->consumeBatch,
+            'limit' => $this->consumeLimit,
+            'idleMillis' => $this->consumeIdleMillis,
+            'autoAck' => $this->consumeAutoAck,
+            'wait' => $this->consumeWait,
+            'timeoutMillis' => $this->consumeTimeoutMillis,
+            'renewLease' => $this->consumeRenewLease,
+            'renewLeaseIntervalMillis' => $this->consumeRenewLeaseIntervalMillis,
+            'subscriptionMode' => $this->consumeSubscriptionMode,
+            'subscriptionFrom' => $this->consumeSubscriptionFrom,
+            'each' => $this->consumeEach,
+        ];
+    }
+
+    private function buildPopPath(): string
+    {
+        if ($this->queueName !== null) {
+            if ($this->partition !== 'Default') {
+                return "/api/v1/pop/queue/{$this->queueName}/partition/{$this->partition}";
+            }
+            return "/api/v1/pop/queue/{$this->queueName}";
+        }
+
+        if ($this->namespace !== null || $this->task !== null) {
+            return '/api/v1/pop';
+        }
+
+        throw new \RuntimeException('Must specify queue, namespace, or task for pop operation');
+    }
+}

--- a/client-laravel/src/Builders/TransactionBuilder.php
+++ b/client-laravel/src/Builders/TransactionBuilder.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Queen\Builders;
+
+use Queen\Http\HttpClient;
+
+class TransactionBuilder
+{
+    private HttpClient $httpClient;
+    private array $operations = [];
+    private array $requiredLeases = [];
+
+    public function __construct(HttpClient $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    public function ack(array|object $messages, string $status = 'completed', array $context = []): static
+    {
+        $msgs = is_array($messages) && (isset($messages[0]) || empty($messages)) ? $messages : [$messages];
+
+        foreach ($msgs as $msg) {
+            if (is_string($msg)) {
+                $transactionId = $msg;
+                $partitionId = null;
+                $leaseId = null;
+            } else {
+                $msg = (array) $msg;
+                $transactionId = $msg['transactionId'] ?? $msg['id'] ?? null;
+                $partitionId = $msg['partitionId'] ?? null;
+                $leaseId = $msg['leaseId'] ?? null;
+            }
+
+            if ($transactionId === null) {
+                throw new \InvalidArgumentException('Message must have transactionId or id property');
+            }
+
+            if ($partitionId === null) {
+                throw new \InvalidArgumentException('Message must have partitionId property to ensure message uniqueness');
+            }
+
+            $operation = [
+                'type' => 'ack',
+                'transactionId' => $transactionId,
+                'partitionId' => $partitionId,
+                'status' => $status,
+            ];
+
+            if (isset($context['consumerGroup'])) {
+                $operation['consumerGroup'] = $context['consumerGroup'];
+            }
+
+            $this->operations[] = $operation;
+
+            if ($leaseId !== null) {
+                $this->requiredLeases[] = $leaseId;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Returns a sub-builder for push operations on a queue
+     */
+    public function queue(string $queueName): TransactionQueueBuilder
+    {
+        return new TransactionQueueBuilder($this, $queueName);
+    }
+
+    /**
+     * @internal Used by TransactionQueueBuilder
+     */
+    public function addPushOperation(string $queueName, ?string $partition, array $items): void
+    {
+        $this->operations[] = [
+            'type' => 'push',
+            'items' => array_map(function (array $item) use ($queueName, $partition) {
+                $payloadValue = $item['data'] ?? $item['payload'] ?? $item;
+
+                $result = [
+                    'queue' => $queueName,
+                    'payload' => $payloadValue,
+                ];
+
+                if ($partition !== null) {
+                    $result['partition'] = $partition;
+                }
+
+                return $result;
+            }, $items),
+        ];
+    }
+
+    public function commit(): array
+    {
+        if (empty($this->operations)) {
+            throw new \RuntimeException('Transaction has no operations to commit');
+        }
+
+        $result = $this->httpClient->post('/api/v1/transaction', [
+            'operations' => $this->operations,
+            'requiredLeases' => array_values(array_unique($this->requiredLeases)),
+        ]);
+
+        if (!($result['success'] ?? false)) {
+            $error = $result['error'] ?? 'Transaction failed';
+            $txId = $result['transactionId'] ?? null;
+            $msg = $txId ? "Transaction {$txId} failed: {$error}" : "Transaction failed: {$error}";
+            throw new \RuntimeException($msg);
+        }
+
+        return $result;
+    }
+}
+
+class TransactionQueueBuilder
+{
+    private TransactionBuilder $parent;
+    private string $queueName;
+    private ?string $partition = null;
+
+    public function __construct(TransactionBuilder $parent, string $queueName)
+    {
+        $this->parent = $parent;
+        $this->queueName = $queueName;
+    }
+
+    public function partition(string $partition): static
+    {
+        $this->partition = $partition;
+        return $this;
+    }
+
+    public function push(array $items): TransactionBuilder
+    {
+        $this->parent->addPushOperation($this->queueName, $this->partition, $items);
+        return $this->parent;
+    }
+}

--- a/client-laravel/src/Consumer/ConsumerManager.php
+++ b/client-laravel/src/Consumer/ConsumerManager.php
@@ -1,0 +1,501 @@
+<?php
+
+namespace Queen\Consumer;
+
+use Queen\Http\HttpClient;
+use Queen\Queen;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
+
+class ConsumerManager
+{
+    private HttpClient $httpClient;
+    private Queen $queen;
+
+    public function __construct(HttpClient $httpClient, Queen $queen)
+    {
+        $this->httpClient = $httpClient;
+        $this->queen = $queen;
+    }
+
+    public function start(\Closure $handler, array $options): void
+    {
+        $queue = $options['queue'] ?? null;
+        $partition = $options['partition'] ?? null;
+        $namespace = $options['namespace'] ?? null;
+        $task = $options['task'] ?? null;
+        $group = $options['group'] ?? null;
+        $concurrency = $options['concurrency'] ?? 1;
+        $batch = $options['batch'] ?? 1;
+        $limit = $options['limit'] ?? null;
+        $idleMillis = $options['idleMillis'] ?? null;
+        $autoAck = $options['autoAck'] ?? true;
+        $wait = $options['wait'] ?? true;
+        $timeoutMillis = $options['timeoutMillis'] ?? 30000;
+        $renewLease = $options['renewLease'] ?? false;
+        $renewLeaseIntervalMillis = $options['renewLeaseIntervalMillis'] ?? null;
+        $each = $options['each'] ?? false;
+        $subscriptionMode = $options['subscriptionMode'] ?? null;
+        $subscriptionFrom = $options['subscriptionFrom'] ?? null;
+
+        $path = $this->buildPath($queue, $partition, $namespace, $task);
+        $baseParams = $this->buildParams($batch, $wait, $timeoutMillis, $group, $subscriptionMode, $subscriptionFrom, $namespace, $task);
+        $affinityKey = $this->getAffinityKey($queue, $partition, $namespace, $task, $group);
+
+        // Install signal handlers, saving previous handlers for restoration
+        $running = true;
+        $prevSigint = null;
+        $prevSigterm = null;
+        if (function_exists('pcntl_signal')) {
+            $prevSigint = pcntl_signal_get_handler(SIGINT);
+            $prevSigterm = pcntl_signal_get_handler(SIGTERM);
+            pcntl_signal(SIGINT, function () use (&$running) {
+                $running = false;
+            });
+            pcntl_signal(SIGTERM, function () use (&$running) {
+                $running = false;
+            });
+        }
+
+        try {
+            if ($concurrency <= 1) {
+                $this->worker(
+                    $handler, $path, $baseParams, $batch, $limit, $idleMillis,
+                    $autoAck, $wait, $timeoutMillis, $renewLease, $renewLeaseIntervalMillis,
+                    $each, $group, $affinityKey, $running
+                );
+            } else {
+                $this->concurrentWorkers(
+                    $concurrency, $handler, $path, $baseParams, $batch, $limit, $idleMillis,
+                    $autoAck, $wait, $timeoutMillis, $renewLease, $renewLeaseIntervalMillis,
+                    $each, $group, $affinityKey, $running
+                );
+            }
+        } finally {
+            // Restore previous signal handlers
+            if (function_exists('pcntl_signal')) {
+                if ($prevSigint !== null) {
+                    pcntl_signal(SIGINT, $prevSigint);
+                }
+                if ($prevSigterm !== null) {
+                    pcntl_signal(SIGTERM, $prevSigterm);
+                }
+            }
+        }
+    }
+
+    /**
+     * Run N concurrent workers using Guzzle async. All workers long-poll
+     * concurrently via cURL multi-handle; processing remains sequential
+     * per-worker but polls overlap.
+     */
+    private function concurrentWorkers(
+        int $concurrency,
+        \Closure $handler,
+        string $path,
+        string $baseParams,
+        int $batch,
+        ?int $limit,
+        ?int $idleMillis,
+        bool $autoAck,
+        bool $wait,
+        int $timeoutMillis,
+        bool $renewLease,
+        ?int $renewLeaseIntervalMillis,
+        bool $each,
+        ?string $group,
+        ?string $affinityKey,
+        bool &$running,
+    ): void {
+        // Per-worker state
+        $workerProcessed = array_fill(0, $concurrency, 0);
+        $workerLastMsg = array_fill(0, $concurrency, $idleMillis !== null ? $this->nowMillis() : null);
+        $perWorkerLimit = $limit !== null ? (int) ceil($limit / $concurrency) : null;
+        $clientTimeout = $wait ? $timeoutMillis + 5000 : $timeoutMillis;
+        $url = "{$path}?{$baseParams}";
+
+        while ($running) {
+            if (function_exists('pcntl_signal_dispatch')) {
+                pcntl_signal_dispatch();
+            }
+            if (!$running) {
+                break;
+            }
+
+            // Determine which workers should poll
+            $activeWorkers = [];
+            for ($w = 0; $w < $concurrency; $w++) {
+                if ($perWorkerLimit !== null && $workerProcessed[$w] >= $perWorkerLimit) {
+                    continue;
+                }
+                if ($idleMillis !== null && $workerLastMsg[$w] !== null) {
+                    if ($this->nowMillis() - $workerLastMsg[$w] >= $idleMillis) {
+                        continue;
+                    }
+                }
+                $activeWorkers[] = $w;
+            }
+
+            if (empty($activeWorkers)) {
+                break; // All workers done
+            }
+
+            // Fire N concurrent long-poll requests
+            $promises = [];
+            foreach ($activeWorkers as $w) {
+                $promises[$w] = $this->httpClient->getAsync($url, $clientTimeout, $affinityKey);
+            }
+
+            // Settle all — don't throw on individual failures
+            $results = HttpClient::settleAll($promises);
+
+            if (function_exists('pcntl_signal_dispatch')) {
+                pcntl_signal_dispatch();
+            }
+            if (!$running) {
+                break;
+            }
+
+            // Process results per worker
+            foreach ($results as $w => $outcome) {
+                if (!$running) {
+                    break;
+                }
+
+                if ($outcome['state'] === 'rejected') {
+                    $error = $outcome['reason'];
+                    $isTimeout = str_contains($error->getMessage(), 'timeout') || str_contains($error->getMessage(), 'timed out');
+                    if ($isTimeout && $wait) {
+                        continue; // Normal for long polling
+                    }
+                    $isNetwork = str_contains($error->getMessage(), 'Connection refused') || str_contains($error->getMessage(), 'cURL error');
+                    if ($isNetwork) {
+                        usleep(1_000_000);
+                        continue;
+                    }
+                    throw $error;
+                }
+
+                $result = $outcome['value'];
+                if (!$result || !isset($result['messages']) || empty($result['messages'])) {
+                    if (!$wait) {
+                        usleep(100_000);
+                    }
+                    continue;
+                }
+
+                $messages = array_values(array_filter($result['messages'], fn($msg) => $msg !== null));
+                if (empty($messages)) {
+                    continue;
+                }
+
+                if ($idleMillis !== null) {
+                    $workerLastMsg[$w] = $this->nowMillis();
+                }
+
+                $this->enhanceMessagesWithTrace($messages, $group);
+
+                $leaseRenewalTime = null;
+                if ($renewLease && $renewLeaseIntervalMillis !== null) {
+                    $leaseRenewalTime = $this->nowMillis() + $renewLeaseIntervalMillis;
+                }
+
+                if ($each) {
+                    foreach ($messages as $message) {
+                        if (!$running) {
+                            break;
+                        }
+                        $this->renewLeaseIfNeeded($messages, $leaseRenewalTime, $renewLeaseIntervalMillis);
+                        $this->processMessage($message, $handler, $autoAck, $group);
+                        $workerProcessed[$w]++;
+                        if ($perWorkerLimit !== null && $workerProcessed[$w] >= $perWorkerLimit) {
+                            break;
+                        }
+                    }
+                } else {
+                    $this->renewLeaseIfNeeded($messages, $leaseRenewalTime, $renewLeaseIntervalMillis);
+                    $this->processBatch($messages, $handler, $autoAck, $group);
+                    $workerProcessed[$w] += count($messages);
+                }
+            }
+
+            // Check global limit
+            if ($limit !== null && array_sum($workerProcessed) >= $limit) {
+                break;
+            }
+        }
+    }
+
+    private function worker(
+        \Closure $handler,
+        string $path,
+        string $baseParams,
+        int $batch,
+        ?int $limit,
+        ?int $idleMillis,
+        bool $autoAck,
+        bool $wait,
+        int $timeoutMillis,
+        bool $renewLease,
+        ?int $renewLeaseIntervalMillis,
+        bool $each,
+        ?string $group,
+        ?string $affinityKey,
+        bool &$running,
+    ): void {
+        $processedCount = 0;
+        $lastMessageTime = $idleMillis !== null ? $this->nowMillis() : null;
+
+        while ($running) {
+            if (function_exists('pcntl_signal_dispatch')) {
+                pcntl_signal_dispatch();
+            }
+
+            if (!$running) {
+                break;
+            }
+
+            if ($limit !== null && $processedCount >= $limit) {
+                break;
+            }
+
+            if ($idleMillis !== null && $lastMessageTime !== null) {
+                $idleTime = $this->nowMillis() - $lastMessageTime;
+                if ($idleTime >= $idleMillis) {
+                    break;
+                }
+            }
+
+            try {
+                $clientTimeout = $wait ? $timeoutMillis + 5000 : $timeoutMillis;
+                $result = $this->httpClient->get("{$path}?{$baseParams}", $clientTimeout, $affinityKey);
+
+                if (!$result || !isset($result['messages']) || empty($result['messages'])) {
+                    if (!$wait) {
+                        usleep(100_000);
+                    }
+                    continue;
+                }
+
+                $messages = array_values(array_filter($result['messages'], fn($msg) => $msg !== null));
+
+                if (empty($messages)) {
+                    continue;
+                }
+
+                if ($idleMillis !== null) {
+                    $lastMessageTime = $this->nowMillis();
+                }
+
+                $this->enhanceMessagesWithTrace($messages, $group);
+
+                $leaseRenewalTime = null;
+                if ($renewLease && $renewLeaseIntervalMillis !== null) {
+                    $leaseRenewalTime = $this->nowMillis() + $renewLeaseIntervalMillis;
+                }
+
+                if ($each) {
+                    foreach ($messages as $message) {
+                        if (!$running) {
+                            break;
+                        }
+
+                        $this->renewLeaseIfNeeded($messages, $leaseRenewalTime, $renewLeaseIntervalMillis);
+                        $this->processMessage($message, $handler, $autoAck, $group);
+                        $processedCount++;
+
+                        if ($limit !== null && $processedCount >= $limit) {
+                            break;
+                        }
+                    }
+                } else {
+                    $this->renewLeaseIfNeeded($messages, $leaseRenewalTime, $renewLeaseIntervalMillis);
+                    $this->processBatch($messages, $handler, $autoAck, $group);
+                    $processedCount += count($messages);
+                }
+            } catch (\Throwable $error) {
+                $isTimeout = str_contains($error->getMessage(), 'timeout') || str_contains($error->getMessage(), 'timed out');
+                if ($isTimeout && $wait) {
+                    continue;
+                }
+
+                $isNetwork = str_contains($error->getMessage(), 'Connection refused') || str_contains($error->getMessage(), 'cURL error');
+                if ($isNetwork) {
+                    usleep(1_000_000);
+                    continue;
+                }
+
+                throw $error;
+            }
+        }
+    }
+
+    private function processMessage(array $message, \Closure $handler, bool $autoAck, ?string $group): void
+    {
+        try {
+            $handler($message);
+
+            if ($autoAck) {
+                $context = $group !== null ? ['group' => $group] : [];
+                $this->queen->ack($message, true, $context);
+            }
+        } catch (\Throwable $error) {
+            if ($autoAck) {
+                $context = $group !== null ? ['group' => $group] : [];
+                $this->queen->ack($message, false, $context);
+                return;
+            }
+            throw $error;
+        }
+    }
+
+    private function processBatch(array $messages, \Closure $handler, bool $autoAck, ?string $group): void
+    {
+        try {
+            $handler($messages);
+
+            if ($autoAck) {
+                $context = $group !== null ? ['group' => $group] : [];
+                $this->queen->ack($messages, true, $context);
+            }
+        } catch (\Throwable $error) {
+            if ($autoAck) {
+                $context = $group !== null ? ['group' => $group] : [];
+                $this->queen->ack($messages, false, $context);
+                return;
+            }
+            throw $error;
+        }
+    }
+
+    private function renewLeaseIfNeeded(array $messages, ?int &$leaseRenewalTime, ?int $intervalMillis): void
+    {
+        if ($leaseRenewalTime === null || $intervalMillis === null) {
+            return;
+        }
+
+        if ($this->nowMillis() >= $leaseRenewalTime) {
+            // Fire async renewal — don't block processing
+            try {
+                $leaseIds = array_filter(array_column($messages, 'leaseId'), fn($id) => $id !== null);
+                $promises = [];
+                foreach ($leaseIds as $leaseId) {
+                    $promises[] = $this->httpClient->postAsync("/api/v1/lease/{$leaseId}/extend", []);
+                }
+                if (!empty($promises)) {
+                    // Settle without throwing — renewal failure is non-fatal
+                    HttpClient::settleAll($promises);
+                }
+            } catch (\Throwable $e) {
+                // Lease renewal failure is non-fatal
+            }
+            $leaseRenewalTime = $this->nowMillis() + $intervalMillis;
+        }
+    }
+
+    private function enhanceMessagesWithTrace(array &$messages, ?string $group): void
+    {
+        $httpClient = $this->httpClient;
+        $consumerGroup = $group ?? '__QUEUE_MODE__';
+
+        foreach ($messages as &$message) {
+            $message['trace'] = function (array $traceConfig) use ($httpClient, $consumerGroup, $message): array {
+                try {
+                    if (!isset($traceConfig['data'])) {
+                        return ['success' => false, 'error' => 'Invalid trace config: requires data key'];
+                    }
+
+                    $traceNames = null;
+                    if (isset($traceConfig['traceName'])) {
+                        $traceNames = is_array($traceConfig['traceName'])
+                            ? array_filter($traceConfig['traceName'], fn($n) => is_string($n) && strlen($n) > 0)
+                            : [$traceConfig['traceName']];
+                        if (empty($traceNames)) {
+                            $traceNames = null;
+                        }
+                    }
+
+                    $response = $httpClient->post('/api/v1/traces', [
+                        'transactionId' => $message['transactionId'],
+                        'partitionId' => $message['partitionId'],
+                        'consumerGroup' => $consumerGroup,
+                        'traceNames' => $traceNames,
+                        'eventType' => $traceConfig['eventType'] ?? 'info',
+                        'data' => $traceConfig['data'],
+                    ]);
+
+                    return array_merge(['success' => true], $response ?? []);
+                } catch (\Throwable $error) {
+                    return ['success' => false, 'error' => $error->getMessage()];
+                }
+            };
+        }
+        unset($message);
+    }
+
+    private function getAffinityKey(?string $queue, ?string $partition, ?string $namespace, ?string $task, ?string $group): ?string
+    {
+        if ($queue !== null) {
+            return "{$queue}:" . ($partition ?? '*') . ':' . ($group ?? '__QUEUE_MODE__');
+        }
+        if ($namespace !== null || $task !== null) {
+            return ($namespace ?? '*') . ':' . ($task ?? '*') . ':' . ($group ?? '__QUEUE_MODE__');
+        }
+        return null;
+    }
+
+    private function buildPath(?string $queue, ?string $partition, ?string $namespace, ?string $task): string
+    {
+        if ($queue !== null) {
+            if ($partition !== null) {
+                return "/api/v1/pop/queue/{$queue}/partition/{$partition}";
+            }
+            return "/api/v1/pop/queue/{$queue}";
+        }
+
+        if ($namespace !== null || $task !== null) {
+            return '/api/v1/pop';
+        }
+
+        throw new \RuntimeException('Must specify queue, namespace, or task');
+    }
+
+    private function buildParams(
+        int $batch,
+        bool $wait,
+        int $timeoutMillis,
+        ?string $group,
+        ?string $subscriptionMode,
+        ?string $subscriptionFrom,
+        ?string $namespace,
+        ?string $task,
+    ): string {
+        $params = [
+            'batch' => (string) $batch,
+            'wait' => $wait ? 'true' : 'false',
+            'timeout' => (string) $timeoutMillis,
+        ];
+
+        if ($group !== null) {
+            $params['consumerGroup'] = $group;
+        }
+        if ($subscriptionMode !== null) {
+            $params['subscriptionMode'] = $subscriptionMode;
+        }
+        if ($subscriptionFrom !== null) {
+            $params['subscriptionFrom'] = $subscriptionFrom;
+        }
+        if ($namespace !== null) {
+            $params['namespace'] = $namespace;
+        }
+        if ($task !== null) {
+            $params['task'] = $task;
+        }
+
+        return http_build_query($params);
+    }
+
+    private function nowMillis(): int
+    {
+        return (int)(microtime(true) * 1000);
+    }
+}

--- a/client-laravel/src/Consumer/HighLevelConsumer.php
+++ b/client-laravel/src/Consumer/HighLevelConsumer.php
@@ -1,0 +1,360 @@
+<?php
+
+namespace Queen\Consumer;
+
+use Queen\Http\HttpClient;
+use Queen\Queen;
+
+/**
+ * High-level consumer inspired by php-rdkafka's KafkaConsumer.
+ *
+ * Usage:
+ *   $consumer = $queen->queue('orders')->group('processors')->batch(10)->getConsumer();
+ *   $consumer->subscribe();
+ *
+ *   while (true) {
+ *       $message = $consumer->consume(1000);
+ *       if ($message === null) continue;
+ *       processMessage($message);
+ *       $consumer->ack($message);
+ *   }
+ *
+ *   $consumer->close();
+ */
+class HighLevelConsumer
+{
+    private HttpClient $httpClient;
+    private Queen $queen;
+    private array $options;
+    private bool $subscribed = false;
+    private bool $closed = false;
+
+    private string $popPath;
+    private string $baseParams;
+    private ?string $affinityKey;
+
+    public function __construct(HttpClient $httpClient, Queen $queen, array $options)
+    {
+        $this->httpClient = $httpClient;
+        $this->queen = $queen;
+        $this->options = $options;
+    }
+
+    /**
+     * Subscribe to the queue (start consuming).
+     * Must be called before consume().
+     */
+    public function subscribe(): void
+    {
+        $queue = $this->options['queue'] ?? null;
+        $partition = $this->options['partition'] ?? null;
+        $namespace = $this->options['namespace'] ?? null;
+        $task = $this->options['task'] ?? null;
+        $group = $this->options['group'] ?? null;
+        $batch = $this->options['batch'] ?? 1;
+        $wait = $this->options['wait'] ?? true;
+        $timeoutMillis = $this->options['timeoutMillis'] ?? 30000;
+        $subscriptionMode = $this->options['subscriptionMode'] ?? null;
+        $subscriptionFrom = $this->options['subscriptionFrom'] ?? null;
+
+        $this->popPath = $this->buildPath($queue, $partition, $namespace, $task);
+        $this->baseParams = $this->buildParams($batch, $wait, $timeoutMillis, $group, $subscriptionMode, $subscriptionFrom, $namespace, $task);
+        $this->affinityKey = $this->getAffinityKey($queue, $partition, $namespace, $task, $group);
+        $this->subscribed = true;
+
+        // Install signal handlers for graceful shutdown
+        if (function_exists('pcntl_signal')) {
+            pcntl_signal(SIGINT, function () {
+                $this->closed = true;
+            });
+            pcntl_signal(SIGTERM, function () {
+                $this->closed = true;
+            });
+        }
+    }
+
+    /**
+     * Consume a single message from the queue.
+     * Returns null if no message available within timeout.
+     *
+     * @param int $timeoutMs Timeout in milliseconds to wait for a message
+     * @return array|null A single message array, or null if no message
+     */
+    public function consume(int $timeoutMs = 1000): ?array
+    {
+        $this->ensureSubscribed();
+
+        if ($this->closed) {
+            return null;
+        }
+
+        if (function_exists('pcntl_signal_dispatch')) {
+            pcntl_signal_dispatch();
+        }
+
+        if ($this->closed) {
+            return null;
+        }
+
+        // Override batch=1 and use the provided timeout
+        $params = $this->baseParams;
+        // Replace batch and timeout in params
+        $parsedParams = [];
+        parse_str($params, $parsedParams);
+        $parsedParams['batch'] = '1';
+        $parsedParams['timeout'] = (string) $timeoutMs;
+        $parsedParams['wait'] = 'true';
+        $queryString = http_build_query($parsedParams);
+
+        try {
+            $clientTimeout = $timeoutMs + 5000;
+            $result = $this->httpClient->get("{$this->popPath}?{$queryString}", $clientTimeout, $this->affinityKey);
+
+            if (!$result || !isset($result['messages']) || empty($result['messages'])) {
+                return null;
+            }
+
+            $messages = array_filter($result['messages'], fn($msg) => $msg !== null);
+            $messages = array_values($messages);
+
+            if (empty($messages)) {
+                return null;
+            }
+
+            $message = $messages[0];
+            $this->enhanceMessageWithTrace($message);
+
+            return $message;
+        } catch (\Throwable $error) {
+            // Timeouts are normal for long polling
+            if (str_contains($error->getMessage(), 'timeout') || str_contains($error->getMessage(), 'timed out')) {
+                return null;
+            }
+
+            // Network errors — return null, caller can retry
+            if (str_contains($error->getMessage(), 'Connection refused') || str_contains($error->getMessage(), 'cURL error')) {
+                return null;
+            }
+
+            throw $error;
+        }
+    }
+
+    /**
+     * Consume a batch of messages from the queue.
+     * Returns empty array if no messages available within timeout.
+     *
+     * @param int $timeoutMs Timeout in milliseconds
+     * @param int $maxMessages Maximum number of messages to return
+     * @return array Array of message arrays
+     */
+    public function consumeBatch(int $timeoutMs = 1000, int $maxMessages = 10): array
+    {
+        $this->ensureSubscribed();
+
+        if ($this->closed) {
+            return [];
+        }
+
+        if (function_exists('pcntl_signal_dispatch')) {
+            pcntl_signal_dispatch();
+        }
+
+        if ($this->closed) {
+            return [];
+        }
+
+        $parsedParams = [];
+        parse_str($this->baseParams, $parsedParams);
+        $parsedParams['batch'] = (string) $maxMessages;
+        $parsedParams['timeout'] = (string) $timeoutMs;
+        $parsedParams['wait'] = 'true';
+        $queryString = http_build_query($parsedParams);
+
+        try {
+            $clientTimeout = $timeoutMs + 5000;
+            $result = $this->httpClient->get("{$this->popPath}?{$queryString}", $clientTimeout, $this->affinityKey);
+
+            if (!$result || !isset($result['messages']) || empty($result['messages'])) {
+                return [];
+            }
+
+            $messages = array_values(array_filter($result['messages'], fn($msg) => $msg !== null));
+
+            foreach ($messages as &$msg) {
+                $this->enhanceMessageWithTrace($msg);
+            }
+            unset($msg);
+
+            return $messages;
+        } catch (\Throwable $error) {
+            if (str_contains($error->getMessage(), 'timeout') || str_contains($error->getMessage(), 'timed out')) {
+                return [];
+            }
+            if (str_contains($error->getMessage(), 'Connection refused') || str_contains($error->getMessage(), 'cURL error')) {
+                return [];
+            }
+            throw $error;
+        }
+    }
+
+    /**
+     * Acknowledge a message (or array of messages).
+     *
+     * @param array $message A single message or array of messages
+     * @param bool $success Whether processing succeeded
+     */
+    public function ack(array $message, bool $success = true): array
+    {
+        $context = [];
+        $group = $this->options['group'] ?? null;
+        if ($group !== null) {
+            $context['group'] = $group;
+        }
+
+        return $this->queen->ack($message, $success, $context);
+    }
+
+    /**
+     * Negative-acknowledge a message (mark as failed).
+     */
+    public function nack(array $message): array
+    {
+        return $this->ack($message, false);
+    }
+
+    /**
+     * Renew lease for a message (or array of messages).
+     */
+    public function renewLease(array|string $messageOrLeaseId): array
+    {
+        return $this->queen->renew($messageOrLeaseId);
+    }
+
+    /**
+     * Check if the consumer has been closed (via signal or close()).
+     */
+    public function isClosed(): bool
+    {
+        if (function_exists('pcntl_signal_dispatch')) {
+            pcntl_signal_dispatch();
+        }
+        return $this->closed;
+    }
+
+    /**
+     * Close the consumer.
+     */
+    public function close(): void
+    {
+        $this->closed = true;
+        $this->subscribed = false;
+    }
+
+    private function ensureSubscribed(): void
+    {
+        if ($this->closed) {
+            return; // Allow graceful exit
+        }
+        if (!$this->subscribed) {
+            throw new \RuntimeException('Consumer not subscribed. Call subscribe() before consume().');
+        }
+    }
+
+    private function enhanceMessageWithTrace(array &$message): void
+    {
+        $httpClient = $this->httpClient;
+        $consumerGroup = $this->options['group'] ?? '__QUEUE_MODE__';
+
+        $message['trace'] = function (array $traceConfig) use ($httpClient, $consumerGroup, $message): array {
+            try {
+                if (!isset($traceConfig['data'])) {
+                    return ['success' => false, 'error' => 'Invalid trace config: requires data key'];
+                }
+
+                $traceNames = null;
+                if (isset($traceConfig['traceName'])) {
+                    $traceNames = is_array($traceConfig['traceName'])
+                        ? array_filter($traceConfig['traceName'], fn($n) => is_string($n) && strlen($n) > 0)
+                        : [$traceConfig['traceName']];
+                    if (empty($traceNames)) {
+                        $traceNames = null;
+                    }
+                }
+
+                $response = $httpClient->post('/api/v1/traces', [
+                    'transactionId' => $message['transactionId'],
+                    'partitionId' => $message['partitionId'],
+                    'consumerGroup' => $consumerGroup,
+                    'traceNames' => $traceNames,
+                    'eventType' => $traceConfig['eventType'] ?? 'info',
+                    'data' => $traceConfig['data'],
+                ]);
+
+                return array_merge(['success' => true], $response ?? []);
+            } catch (\Throwable $error) {
+                return ['success' => false, 'error' => $error->getMessage()];
+            }
+        };
+    }
+
+    private function getAffinityKey(?string $queue, ?string $partition, ?string $namespace, ?string $task, ?string $group): ?string
+    {
+        if ($queue !== null) {
+            return "{$queue}:" . ($partition ?? '*') . ':' . ($group ?? '__QUEUE_MODE__');
+        }
+        if ($namespace !== null || $task !== null) {
+            return ($namespace ?? '*') . ':' . ($task ?? '*') . ':' . ($group ?? '__QUEUE_MODE__');
+        }
+        return null;
+    }
+
+    private function buildPath(?string $queue, ?string $partition, ?string $namespace, ?string $task): string
+    {
+        if ($queue !== null) {
+            if ($partition !== null) {
+                return "/api/v1/pop/queue/{$queue}/partition/{$partition}";
+            }
+            return "/api/v1/pop/queue/{$queue}";
+        }
+        if ($namespace !== null || $task !== null) {
+            return '/api/v1/pop';
+        }
+        throw new \RuntimeException('Must specify queue, namespace, or task');
+    }
+
+    private function buildParams(
+        int $batch,
+        bool $wait,
+        int $timeoutMillis,
+        ?string $group,
+        ?string $subscriptionMode,
+        ?string $subscriptionFrom,
+        ?string $namespace,
+        ?string $task,
+    ): string {
+        $params = [
+            'batch' => (string) $batch,
+            'wait' => $wait ? 'true' : 'false',
+            'timeout' => (string) $timeoutMillis,
+        ];
+
+        if ($group !== null) {
+            $params['consumerGroup'] = $group;
+        }
+        if ($subscriptionMode !== null) {
+            $params['subscriptionMode'] = $subscriptionMode;
+        }
+        if ($subscriptionFrom !== null) {
+            $params['subscriptionFrom'] = $subscriptionFrom;
+        }
+        if ($namespace !== null) {
+            $params['namespace'] = $namespace;
+        }
+        if ($task !== null) {
+            $params['task'] = $task;
+        }
+
+        return http_build_query($params);
+    }
+}

--- a/client-laravel/src/Exceptions/HttpException.php
+++ b/client-laravel/src/Exceptions/HttpException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Queen\Exceptions;
+
+class HttpException extends \RuntimeException
+{
+    public function __construct(
+        string $message,
+        public readonly int $statusCode,
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/client-laravel/src/Http/HttpClient.php
+++ b/client-laravel/src/Http/HttpClient.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace Queen\Http;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
+use Psr\Http\Message\ResponseInterface;
+use Queen\Exceptions\HttpException;
+
+class HttpClient
+{
+    private ?string $baseUrl;
+    private ?LoadBalancer $loadBalancer;
+    private int $timeoutMillis;
+    private int $retryAttempts;
+    private int $retryDelayMillis;
+    private bool $enableFailover;
+    private ?string $bearerToken;
+    private array $headers;
+    private Client $guzzle;
+
+    public function __construct(array $options = [])
+    {
+        $this->baseUrl = $options['baseUrl'] ?? null;
+        $this->loadBalancer = $options['loadBalancer'] ?? null;
+        $this->timeoutMillis = $options['timeoutMillis'] ?? 30000;
+        $this->retryAttempts = $options['retryAttempts'] ?? 3;
+        $this->retryDelayMillis = $options['retryDelayMillis'] ?? 1000;
+        $this->enableFailover = $options['enableFailover'] ?? true;
+        $this->bearerToken = $options['bearerToken'] ?? null;
+        $this->headers = $options['headers'] ?? [];
+        $this->guzzle = new Client();
+    }
+
+    // ===========================
+    // Synchronous API
+    // ===========================
+
+    public function get(string $path, ?int $requestTimeoutMillis = null, ?string $affinityKey = null): mixed
+    {
+        return $this->requestWithFailover('GET', $path, null, $requestTimeoutMillis, $affinityKey);
+    }
+
+    public function post(string $path, ?array $body = null, ?int $requestTimeoutMillis = null, ?string $affinityKey = null): mixed
+    {
+        return $this->requestWithFailover('POST', $path, $body, $requestTimeoutMillis, $affinityKey);
+    }
+
+    public function put(string $path, ?array $body = null, ?int $requestTimeoutMillis = null, ?string $affinityKey = null): mixed
+    {
+        return $this->requestWithFailover('PUT', $path, $body, $requestTimeoutMillis, $affinityKey);
+    }
+
+    public function delete(string $path, ?int $requestTimeoutMillis = null, ?string $affinityKey = null): mixed
+    {
+        return $this->requestWithFailover('DELETE', $path, null, $requestTimeoutMillis, $affinityKey);
+    }
+
+    // ===========================
+    // Async API (returns Guzzle promises)
+    // ===========================
+
+    public function getAsync(string $path, ?int $requestTimeoutMillis = null, ?string $affinityKey = null): PromiseInterface
+    {
+        return $this->executeRequestAsync($this->resolveUrl($affinityKey) . $path, 'GET', null, $requestTimeoutMillis);
+    }
+
+    public function postAsync(string $path, ?array $body = null, ?int $requestTimeoutMillis = null, ?string $affinityKey = null): PromiseInterface
+    {
+        return $this->executeRequestAsync($this->resolveUrl($affinityKey) . $path, 'POST', $body, $requestTimeoutMillis);
+    }
+
+    public function putAsync(string $path, ?array $body = null, ?int $requestTimeoutMillis = null, ?string $affinityKey = null): PromiseInterface
+    {
+        return $this->executeRequestAsync($this->resolveUrl($affinityKey) . $path, 'PUT', $body, $requestTimeoutMillis);
+    }
+
+    public function deleteAsync(string $path, ?int $requestTimeoutMillis = null, ?string $affinityKey = null): PromiseInterface
+    {
+        return $this->executeRequestAsync($this->resolveUrl($affinityKey) . $path, 'DELETE', null, $requestTimeoutMillis);
+    }
+
+    /**
+     * Wait for multiple promises to resolve concurrently.
+     *
+     * @param PromiseInterface[] $promises
+     * @return array Results indexed same as input
+     */
+    public static function awaitAll(array $promises): array
+    {
+        return PromiseUtils::unwrap($promises);
+    }
+
+    /**
+     * Settle all promises (no exceptions on failure). Returns array of
+     * ['state' => 'fulfilled'|'rejected', 'value' => ..., 'reason' => ...]
+     *
+     * @param PromiseInterface[] $promises
+     * @return array
+     */
+    public static function settleAll(array $promises): array
+    {
+        return PromiseUtils::settle($promises)->wait();
+    }
+
+    // ===========================
+    // Internals
+    // ===========================
+
+    public function getLoadBalancer(): ?LoadBalancer
+    {
+        return $this->loadBalancer;
+    }
+
+    private function resolveUrl(?string $affinityKey = null): string
+    {
+        if ($this->loadBalancer !== null) {
+            return $this->loadBalancer->getNextUrl($affinityKey);
+        }
+        if ($this->baseUrl === null) {
+            throw new \LogicException('HttpClient has no baseUrl and no LoadBalancer configured');
+        }
+        return $this->baseUrl;
+    }
+
+    private function buildRequestOptions(string $method, ?array $body, ?int $requestTimeoutMillis): array
+    {
+        $effectiveTimeout = $requestTimeoutMillis ?? $this->timeoutMillis;
+
+        $headers = ['Content-Type' => 'application/json'];
+        if ($this->bearerToken !== null) {
+            $headers['Authorization'] = "Bearer {$this->bearerToken}";
+        }
+        $headers = array_merge($headers, $this->headers);
+
+        $options = [
+            'headers' => $headers,
+            'timeout' => $effectiveTimeout / 1000,
+            'connect_timeout' => 5,
+            'http_errors' => false,
+        ];
+
+        if ($body !== null) {
+            $options['json'] = $body;
+        }
+
+        return $options;
+    }
+
+    private function parseResponse(ResponseInterface $response): mixed
+    {
+        $statusCode = $response->getStatusCode();
+
+        if ($statusCode === 204) {
+            return null;
+        }
+
+        $responseBody = (string) $response->getBody();
+
+        if ($statusCode >= 400) {
+            $error = "HTTP {$statusCode}";
+            if ($responseBody) {
+                $decoded = json_decode($responseBody, true);
+                if (isset($decoded['error'])) {
+                    $error = $decoded['error'];
+                }
+            }
+            throw new HttpException($error, $statusCode);
+        }
+
+        if (empty($responseBody)) {
+            return null;
+        }
+
+        return json_decode($responseBody, true);
+    }
+
+    private function executeRequest(string $url, string $method, ?array $body = null, ?int $requestTimeoutMillis = null): mixed
+    {
+        $options = $this->buildRequestOptions($method, $body, $requestTimeoutMillis);
+        $response = $this->guzzle->request($method, $url, $options);
+        return $this->parseResponse($response);
+    }
+
+    private function executeRequestAsync(string $url, string $method, ?array $body = null, ?int $requestTimeoutMillis = null): PromiseInterface
+    {
+        $options = $this->buildRequestOptions($method, $body, $requestTimeoutMillis);
+
+        return $this->guzzle->requestAsync($method, $url, $options)->then(
+            fn(ResponseInterface $response) => $this->parseResponse($response)
+        );
+    }
+
+    private function getStatusCode(\Throwable $error): int
+    {
+        return ($error instanceof HttpException) ? $error->statusCode : 0;
+    }
+
+    private function requestWithRetry(string $method, string $path, ?array $body = null, ?int $requestTimeoutMillis = null, ?string $affinityKey = null): mixed
+    {
+        $lastError = null;
+
+        for ($attempt = 0; $attempt < $this->retryAttempts; $attempt++) {
+            try {
+                $url = $this->resolveUrl($affinityKey) . $path;
+                return $this->executeRequest($url, $method, $body, $requestTimeoutMillis);
+            } catch (\Throwable $error) {
+                $lastError = $error;
+
+                $statusCode = $this->getStatusCode($error);
+                if ($statusCode >= 400 && $statusCode < 500) {
+                    throw $error;
+                }
+
+                if ($attempt < $this->retryAttempts - 1) {
+                    $delay = $this->retryDelayMillis * (2 ** $attempt);
+                    usleep($delay * 1000);
+                }
+            }
+        }
+
+        throw $lastError;
+    }
+
+    private function requestWithFailover(string $method, string $path, ?array $body = null, ?int $requestTimeoutMillis = null, ?string $affinityKey = null): mixed
+    {
+        if ($this->loadBalancer === null || !$this->enableFailover) {
+            return $this->requestWithRetry($method, $path, $body, $requestTimeoutMillis, $affinityKey);
+        }
+
+        $urls = $this->loadBalancer->getAllUrls();
+        $attemptedUrls = [];
+        $lastError = null;
+
+        for ($i = 0; $i < count($urls); $i++) {
+            $url = $this->loadBalancer->getNextUrl($affinityKey);
+
+            if (in_array($url, $attemptedUrls, true)) {
+                continue;
+            }
+
+            $attemptedUrls[] = $url;
+
+            try {
+                $result = $this->executeRequest($url . $path, $method, $body, $requestTimeoutMillis);
+                $this->loadBalancer->markHealthy($url);
+                return $result;
+            } catch (\Throwable $error) {
+                $lastError = $error;
+
+                $statusCode = $this->getStatusCode($error);
+                if ($statusCode === 0 || $statusCode >= 500) {
+                    $this->loadBalancer->markUnhealthy($url);
+                }
+
+                if ($statusCode >= 400 && $statusCode < 500) {
+                    throw $error;
+                }
+            }
+        }
+
+        throw $lastError ?? new \RuntimeException('All servers failed');
+    }
+}

--- a/client-laravel/src/Http/LoadBalancer.php
+++ b/client-laravel/src/Http/LoadBalancer.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Queen\Http;
+
+class LoadBalancer
+{
+    private array $urls;
+    private string $strategy;
+    private int $currentIndex = 0;
+    private array $sessionMap = [];
+    private string $sessionId;
+    private array $healthStatus = [];
+    private ?array $virtualNodes = null;
+    private int $affinityHashRing;
+    private int $healthRetryAfterMillis;
+
+    public function __construct(array $urls, string $strategy = 'round-robin', array $options = [])
+    {
+        $this->urls = array_map(fn(string $url) => rtrim($url, '/'), $urls);
+        $this->strategy = $strategy;
+        $this->sessionId = 'session_' . time() . '_' . bin2hex(random_bytes(5));
+        $this->affinityHashRing = $options['affinityHashRing'] ?? 150;
+        $this->healthRetryAfterMillis = $options['healthRetryAfterMillis'] ?? 30000;
+
+        foreach ($this->urls as $url) {
+            $this->healthStatus[$url] = [
+                'healthy' => true,
+                'failures' => 0,
+                'lastFailure' => null,
+            ];
+        }
+
+        if ($strategy === 'affinity') {
+            $this->buildVirtualNodeRing();
+        }
+    }
+
+    private function buildVirtualNodeRing(?array $urls = null): void
+    {
+        $urlsToUse = $urls ?? $this->urls;
+        $this->virtualNodes = [];
+
+        foreach ($urlsToUse as $url) {
+            for ($i = 0; $i < $this->affinityHashRing; $i++) {
+                $vnodeKey = "{$url}#vnode{$i}";
+                $this->virtualNodes[] = [
+                    'hash' => $this->hashString($vnodeKey),
+                    'realServer' => $url,
+                ];
+            }
+        }
+
+        usort($this->virtualNodes, fn($a, $b) => $a['hash'] <=> $b['hash']);
+    }
+
+    public function getNextUrl(?string $sessionKey = null): string
+    {
+        $key = $sessionKey ?? $this->sessionId;
+        $now = (int)(microtime(true) * 1000);
+        $needRingRebuild = false;
+
+        $healthyUrls = array_values(array_filter($this->urls, function (string $url) use ($now, &$needRingRebuild) {
+            $status = $this->healthStatus[$url];
+            if ($status['healthy']) {
+                return true;
+            }
+            if ($status['lastFailure'] !== null && ($now - $status['lastFailure']) >= $this->healthRetryAfterMillis) {
+                $needRingRebuild = true;
+                return true;
+            }
+            return false;
+        }));
+
+        if ($needRingRebuild && $this->virtualNodes !== null) {
+            $this->buildVirtualNodeRing($healthyUrls);
+        }
+
+        if (empty($healthyUrls)) {
+            return $this->urls[$this->currentIndex % count($this->urls)];
+        }
+
+        if ($this->strategy === 'affinity') {
+            return $this->getAffinityUrl($key, $healthyUrls);
+        }
+
+        if ($this->strategy === 'session') {
+            if (!isset($this->sessionMap[$key])) {
+                $this->sessionMap[$key] = $this->currentIndex;
+                $this->currentIndex = ($this->currentIndex + 1) % count($healthyUrls);
+            }
+
+            $assignedUrl = $this->urls[$this->sessionMap[$key]] ?? $healthyUrls[0];
+            if (!in_array($assignedUrl, $healthyUrls, true)) {
+                $newIndex = $this->currentIndex % count($healthyUrls);
+                $this->sessionMap[$key] = $newIndex;
+                $this->currentIndex = ($this->currentIndex + 1) % count($healthyUrls);
+                return $healthyUrls[$newIndex];
+            }
+
+            return $assignedUrl;
+        }
+
+        // Round robin
+        $url = $healthyUrls[$this->currentIndex % count($healthyUrls)];
+        $this->currentIndex = ($this->currentIndex + 1) % count($healthyUrls);
+        return $url;
+    }
+
+    private function getAffinityUrl(string $key, array $healthyUrls): string
+    {
+        if (empty($this->virtualNodes)) {
+            $url = $healthyUrls[$this->currentIndex % count($healthyUrls)];
+            $this->currentIndex = ($this->currentIndex + 1) % count($healthyUrls);
+            return $url;
+        }
+
+        $keyHash = $this->hashString($key);
+
+        // Binary search for first vnode >= keyHash
+        $left = 0;
+        $right = count($this->virtualNodes) - 1;
+        $result = 0;
+
+        while ($left <= $right) {
+            $mid = intdiv($left + $right, 2);
+            if ($this->virtualNodes[$mid]['hash'] >= $keyHash) {
+                $result = $mid;
+                $right = $mid - 1;
+            } else {
+                $left = $mid + 1;
+            }
+        }
+
+        // Walk forward to find first healthy server
+        $count = count($this->virtualNodes);
+        for ($i = 0; $i < $count; $i++) {
+            $idx = ($result + $i) % $count;
+            $vnode = $this->virtualNodes[$idx];
+            if (in_array($vnode['realServer'], $healthyUrls, true)) {
+                return $vnode['realServer'];
+            }
+        }
+
+        return $healthyUrls[0];
+    }
+
+    /**
+     * FNV-1a hash function matching the JS implementation.
+     * All intermediate operations masked to 32-bit to prevent
+     * 64-bit PHP integer overflow producing wrong results.
+     */
+    private function hashString(string $str): int
+    {
+        $hash = 2166136261; // FNV offset basis
+
+        for ($i = 0, $len = strlen($str); $i < $len; $i++) {
+            $hash = ($hash ^ ord($str[$i])) & 0xFFFFFFFF;
+            // Replicate JS: hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24)
+            $hash = ($hash
+                + (($hash << 1) & 0xFFFFFFFF)
+                + (($hash << 4) & 0xFFFFFFFF)
+                + (($hash << 7) & 0xFFFFFFFF)
+                + (($hash << 8) & 0xFFFFFFFF)
+                + (($hash << 24) & 0xFFFFFFFF)
+            ) & 0xFFFFFFFF;
+        }
+
+        return $hash;
+    }
+
+    public function markUnhealthy(string $url): void
+    {
+        if (!isset($this->healthStatus[$url])) {
+            return;
+        }
+
+        $this->healthStatus[$url]['healthy'] = false;
+        $this->healthStatus[$url]['failures']++;
+        $this->healthStatus[$url]['lastFailure'] = (int)(microtime(true) * 1000);
+
+        if ($this->virtualNodes !== null) {
+            $healthyUrls = array_values(array_filter($this->urls, fn($u) => $this->healthStatus[$u]['healthy']));
+            $this->buildVirtualNodeRing($healthyUrls);
+        }
+    }
+
+    public function markHealthy(string $url): void
+    {
+        if (!isset($this->healthStatus[$url])) {
+            return;
+        }
+
+        $wasUnhealthy = !$this->healthStatus[$url]['healthy'];
+        $this->healthStatus[$url]['healthy'] = true;
+        $this->healthStatus[$url]['failures'] = 0;
+        $this->healthStatus[$url]['lastFailure'] = null;
+
+        if ($this->virtualNodes !== null && $wasUnhealthy) {
+            $this->buildVirtualNodeRing();
+        }
+    }
+
+    public function getHealthStatus(): array
+    {
+        return $this->healthStatus;
+    }
+
+    public function getAllUrls(): array
+    {
+        return $this->urls;
+    }
+
+    public function getStrategy(): string
+    {
+        return $this->strategy;
+    }
+}

--- a/client-laravel/src/Laravel/Commands/ConsumeCommand.php
+++ b/client-laravel/src/Laravel/Commands/ConsumeCommand.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Queen\Laravel\Commands;
+
+use Illuminate\Console\Command;
+use Queen\Queen;
+
+class ConsumeCommand extends Command
+{
+    protected $signature = 'queen:consume
+        {queue : Queue name to consume from}
+        {handler : Fully qualified class name with handle() method}
+        {--group= : Consumer group name}
+        {--batch=1 : Number of messages per batch}
+        {--auto-ack : Enable auto-acknowledgment}
+        {--subscription-mode= : Subscription mode}
+        {--subscription-from= : Subscription start point}
+        {--timeout=30000 : Long poll timeout in milliseconds}
+        {--idle-timeout= : Stop after N milliseconds of inactivity}
+        {--limit= : Stop after processing N messages}';
+
+    protected $description = 'Consume messages from a Queen MQ queue';
+
+    public function handle(Queen $queen): int
+    {
+        $queueName = $this->argument('queue');
+        $handlerClass = $this->argument('handler');
+
+        if (!class_exists($handlerClass)) {
+            $this->error("Handler class not found: {$handlerClass}");
+            return self::FAILURE;
+        }
+
+        $handler = app($handlerClass);
+        if (!method_exists($handler, 'handle')) {
+            $this->error("Handler class must have a handle() method: {$handlerClass}");
+            return self::FAILURE;
+        }
+
+        $this->info("Starting Queen consumer on queue: {$queueName}");
+
+        $builder = $queen->queue($queueName)
+            ->batch((int) $this->option('batch'));
+
+        if ($this->option('group')) {
+            $builder->group($this->option('group'));
+            $this->info("Consumer group: {$this->option('group')}");
+        }
+
+        if ($this->option('auto-ack')) {
+            $builder->autoAck(true);
+        }
+
+        if ($this->option('subscription-mode')) {
+            $builder->subscriptionMode($this->option('subscription-mode'));
+        }
+
+        if ($this->option('subscription-from')) {
+            $builder->subscriptionFrom($this->option('subscription-from'));
+        }
+
+        if ($this->option('idle-timeout')) {
+            $builder->idleMillis((int) $this->option('idle-timeout'));
+        }
+
+        if ($this->option('limit')) {
+            $builder->limit((int) $this->option('limit'));
+        }
+
+        // Use the high-level consumer (rdkafka-style)
+        $consumer = $builder->getConsumer();
+        $consumer->subscribe();
+
+        $this->info('Consumer subscribed. Waiting for messages... (Ctrl+C to stop)');
+
+        $processed = 0;
+        $batch = (int) $this->option('batch');
+        $autoAck = $this->option('auto-ack');
+        $timeout = (int) $this->option('timeout');
+        $limit = $this->option('limit') ? (int) $this->option('limit') : null;
+
+        while (!$consumer->isClosed()) {
+            if ($batch > 1) {
+                $messages = $consumer->consumeBatch($timeout, $batch);
+                if (empty($messages)) {
+                    continue;
+                }
+
+                try {
+                    $handler->handle($messages);
+                    if ($autoAck) {
+                        $consumer->ack($messages);
+                    }
+                    $processed += count($messages);
+                } catch (\Throwable $e) {
+                    $this->error("Error processing batch: {$e->getMessage()}");
+                    if ($autoAck) {
+                        $consumer->nack($messages);
+                    }
+                }
+            } else {
+                $message = $consumer->consume($timeout);
+                if ($message === null) {
+                    continue;
+                }
+
+                try {
+                    $handler->handle($message);
+                    if ($autoAck) {
+                        $consumer->ack($message);
+                    }
+                    $processed++;
+                } catch (\Throwable $e) {
+                    $this->error("Error processing message: {$e->getMessage()}");
+                    if ($autoAck) {
+                        $consumer->nack($message);
+                    }
+                }
+            }
+
+            if ($limit !== null && $processed >= $limit) {
+                $this->info("Message limit reached ({$limit})");
+                break;
+            }
+        }
+
+        $consumer->close();
+        $this->info("Consumer stopped. Processed {$processed} messages.");
+
+        return self::SUCCESS;
+    }
+}

--- a/client-laravel/src/Laravel/QueenFacade.php
+++ b/client-laravel/src/Laravel/QueenFacade.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Queen\Laravel;
+
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * @method static \Queen\Builders\QueueBuilder queue(?string $name = null)
+ * @method static \Queen\Builders\TransactionBuilder transaction()
+ * @method static \Queen\Admin admin()
+ * @method static array ack(array|string $message, bool|string $status = true, array $context = [])
+ * @method static array renew(string|array $messageOrLeaseId)
+ * @method static void flushAllBuffers()
+ * @method static array getBufferStats()
+ * @method static void close()
+ *
+ * @see \Queen\Queen
+ */
+class QueenFacade extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'queen';
+    }
+}

--- a/client-laravel/src/Laravel/QueenServiceProvider.php
+++ b/client-laravel/src/Laravel/QueenServiceProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Queen\Laravel;
+
+use Illuminate\Support\ServiceProvider;
+use Queen\Queen;
+
+class QueenServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../../config/queen.php', 'queen');
+
+        $this->app->singleton(Queen::class, function ($app) {
+            $config = $app['config']['queen'];
+
+            $queenConfig = [
+                'bearerToken' => $config['bearer_token'],
+                'timeoutMillis' => $config['timeout'],
+                'retryAttempts' => $config['retry_attempts'],
+                'retryDelayMillis' => $config['retry_delay'] ?? 1000,
+                'loadBalancingStrategy' => $config['load_balancing_strategy'],
+                'enableFailover' => $config['enable_failover'] ?? true,
+                'affinityHashRing' => $config['affinity_hash_ring'] ?? 150,
+                'healthRetryAfterMillis' => $config['health_retry_after'] ?? 30000,
+                'headers' => $config['headers'] ?? [],
+            ];
+
+            if (!empty($config['urls'])) {
+                $queenConfig['urls'] = $config['urls'];
+            } else {
+                $queenConfig['url'] = $config['url'];
+            }
+
+            return new Queen($queenConfig);
+        });
+
+        $this->app->alias(Queen::class, 'queen');
+    }
+
+    public function boot(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__ . '/../../config/queen.php' => config_path('queen.php'),
+            ], 'queen-config');
+
+            $this->commands([
+                Commands\ConsumeCommand::class,
+            ]);
+        }
+    }
+}

--- a/client-laravel/src/Queen.php
+++ b/client-laravel/src/Queen.php
@@ -1,0 +1,340 @@
+<?php
+
+namespace Queen;
+
+use Queen\Http\HttpClient;
+use Queen\Http\LoadBalancer;
+use Queen\Buffer\BufferManager;
+use Queen\Builders\QueueBuilder;
+use Queen\Builders\TransactionBuilder;
+use Queen\Support\Defaults;
+
+class Queen
+{
+    private HttpClient $httpClient;
+    private BufferManager $bufferManager;
+    private array $config;
+    private ?Admin $admin = null;
+
+    /**
+     * @param string|array $config Single URL string, array of URLs, or config array
+     */
+    public function __construct(string|array $config = [])
+    {
+        $this->config = $this->normalizeConfig($config);
+        $this->httpClient = $this->createHttpClient();
+        $this->bufferManager = new BufferManager($this->httpClient);
+    }
+
+    // ===========================
+    // Queue Builder Entry Point
+    // ===========================
+
+    public function queue(?string $name = null): QueueBuilder
+    {
+        return new QueueBuilder($this, $this->httpClient, $this->bufferManager, $name);
+    }
+
+    // ===========================
+    // Admin API
+    // ===========================
+
+    public function admin(): Admin
+    {
+        if ($this->admin === null) {
+            $this->admin = new Admin($this->httpClient);
+        }
+        return $this->admin;
+    }
+
+    // ===========================
+    // Transaction API
+    // ===========================
+
+    public function transaction(): TransactionBuilder
+    {
+        return new TransactionBuilder($this->httpClient);
+    }
+
+    // ===========================
+    // Direct ACK API
+    // ===========================
+
+    /**
+     * @param array|string $message Single message, array of messages, or transaction ID string
+     * @param bool|string $status true/false or 'completed'/'failed'
+     * @param array $context Optional context (group, error)
+     */
+    public function ack(array|string $message, bool|string $status = true, array $context = []): array
+    {
+        // Batch ack
+        $isBatch = is_array($message) && (isset($message[0]) || empty($message));
+
+        if ($isBatch) {
+            if (empty($message)) {
+                return ['processed' => 0, 'results' => []];
+            }
+
+            $hasIndividualStatus = false;
+            foreach ($message as $msg) {
+                if (is_array($msg) && (array_key_exists('_status', $msg) || array_key_exists('_error', $msg))) {
+                    $hasIndividualStatus = true;
+                    break;
+                }
+            }
+
+            try {
+                $acknowledgments = array_map(function ($msg) use ($status, $context, $hasIndividualStatus) {
+                    return $this->buildAck($msg, $status, $context, $hasIndividualStatus);
+                }, $message);
+
+                $result = $this->httpClient->post('/api/v1/ack/batch', [
+                    'acknowledgments' => $acknowledgments,
+                    'consumerGroup' => $context['group'] ?? null,
+                ]);
+
+                if (is_array($result) && isset($result['error'])) {
+                    return ['success' => false, 'error' => $result['error']];
+                }
+
+                return array_merge(['success' => true], $result ?? []);
+            } catch (\Throwable $error) {
+                return ['success' => false, 'error' => $error->getMessage()];
+            }
+        }
+
+        // Single ack
+        $msg = is_string($message) ? ['transactionId' => $message] : $message;
+        $transactionId = $msg['transactionId'] ?? $msg['id'] ?? null;
+        $partitionId = $msg['partitionId'] ?? null;
+        $leaseId = $msg['leaseId'] ?? null;
+
+        if ($transactionId === null) {
+            return ['success' => false, 'error' => 'Message must have transactionId or id property'];
+        }
+
+        if ($partitionId === null) {
+            return ['success' => false, 'error' => 'Message must have partitionId property to ensure message uniqueness'];
+        }
+
+        $statusStr = is_bool($status) ? ($status ? 'completed' : 'failed') : $status;
+
+        $body = [
+            'transactionId' => $transactionId,
+            'partitionId' => $partitionId,
+            'status' => $statusStr,
+            'error' => $context['error'] ?? null,
+            'consumerGroup' => $context['group'] ?? null,
+        ];
+
+        if ($leaseId !== null) {
+            $body['leaseId'] = $leaseId;
+        }
+
+        try {
+            $result = $this->httpClient->post('/api/v1/ack', $body);
+
+            if (is_array($result) && isset($result['error'])) {
+                return ['success' => false, 'error' => $result['error']];
+            }
+
+            return array_merge(['success' => true], $result ?? []);
+        } catch (\Throwable $error) {
+            return ['success' => false, 'error' => $error->getMessage()];
+        }
+    }
+
+    // ===========================
+    // Lease Renewal API
+    // ===========================
+
+    /**
+     * @param string|array $messageOrLeaseId Lease ID string, message array, or array of messages
+     */
+    public function renew(string|array $messageOrLeaseId): array
+    {
+        $leaseIds = [];
+
+        if (is_string($messageOrLeaseId)) {
+            $leaseIds = [$messageOrLeaseId];
+        } elseif (isset($messageOrLeaseId[0])) {
+            // Array of messages or lease IDs
+            foreach ($messageOrLeaseId as $item) {
+                if (is_string($item)) {
+                    $leaseIds[] = $item;
+                } elseif (is_array($item) && isset($item['leaseId'])) {
+                    $leaseIds[] = $item['leaseId'];
+                }
+            }
+        } elseif (isset($messageOrLeaseId['leaseId'])) {
+            $leaseIds = [$messageOrLeaseId['leaseId']];
+        }
+
+        if (empty($leaseIds)) {
+            return ['success' => false, 'error' => 'No valid lease IDs found for renewal'];
+        }
+
+        $results = [];
+        foreach ($leaseIds as $leaseId) {
+            try {
+                $result = $this->httpClient->post("/api/v1/lease/{$leaseId}/extend", []);
+                $results[] = [
+                    'leaseId' => $leaseId,
+                    'success' => true,
+                    'newExpiresAt' => $result['newExpiresAt'] ?? $result['lease_expires_at'] ?? null,
+                ];
+            } catch (\Throwable $error) {
+                $results[] = ['leaseId' => $leaseId, 'success' => false, 'error' => $error->getMessage()];
+            }
+        }
+
+        // Return single result if single input
+        return is_string($messageOrLeaseId) || !isset($messageOrLeaseId[0])
+            ? $results[0]
+            : $results;
+    }
+
+    // ===========================
+    // Buffer Management
+    // ===========================
+
+    public function flushAllBuffers(): void
+    {
+        $this->bufferManager->flushAllBuffers();
+    }
+
+    public function getBufferStats(): array
+    {
+        return $this->bufferManager->getStats();
+    }
+
+    // ===========================
+    // Consumer Group Management
+    // ===========================
+
+    public function deleteConsumerGroup(string $consumerGroup, bool $deleteMetadata = true): mixed
+    {
+        $dm = $deleteMetadata ? 'true' : 'false';
+        return $this->httpClient->delete("/api/v1/consumer-groups/" . urlencode($consumerGroup) . "?deleteMetadata={$dm}");
+    }
+
+    public function updateConsumerGroupTimestamp(string $consumerGroup, string $timestamp): mixed
+    {
+        return $this->httpClient->post("/api/v1/consumer-groups/" . urlencode($consumerGroup) . "/subscription", [
+            'subscriptionTimestamp' => $timestamp,
+        ]);
+    }
+
+    // ===========================
+    // Graceful Shutdown
+    // ===========================
+
+    public function close(): void
+    {
+        try {
+            $this->bufferManager->flushAllBuffers();
+        } catch (\Throwable $error) {
+            // Best effort
+        }
+        $this->bufferManager->cleanup();
+    }
+
+    // ===========================
+    // Internal
+    // ===========================
+
+    private function normalizeConfig(string|array $config): array
+    {
+        if (is_string($config)) {
+            return array_merge(Defaults::CLIENT_DEFAULTS, ['urls' => [$config]]);
+        }
+
+        // Array of URLs (sequential numeric keys)
+        if (isset($config[0])) {
+            return array_merge(Defaults::CLIENT_DEFAULTS, ['urls' => $config]);
+        }
+
+        // Config array
+        $normalized = array_merge(Defaults::CLIENT_DEFAULTS, $config);
+
+        if (isset($normalized['urls'])) {
+            // Already set
+        } elseif (isset($normalized['url'])) {
+            $normalized['urls'] = [$normalized['url']];
+        } else {
+            throw new \InvalidArgumentException('Must provide urls or url in configuration');
+        }
+
+        return $normalized;
+    }
+
+    private function createHttpClient(): HttpClient
+    {
+        $urls = $this->config['urls'];
+        $timeoutMillis = $this->config['timeoutMillis'];
+        $retryAttempts = $this->config['retryAttempts'];
+        $retryDelayMillis = $this->config['retryDelayMillis'];
+        $bearerToken = $this->config['bearerToken'];
+        $headers = $this->config['headers'];
+
+        if (count($urls) === 1) {
+            return new HttpClient([
+                'baseUrl' => $urls[0],
+                'timeoutMillis' => $timeoutMillis,
+                'retryAttempts' => $retryAttempts,
+                'retryDelayMillis' => $retryDelayMillis,
+                'bearerToken' => $bearerToken,
+                'headers' => $headers,
+            ]);
+        }
+
+        $loadBalancer = new LoadBalancer($urls, $this->config['loadBalancingStrategy'], [
+            'affinityHashRing' => $this->config['affinityHashRing'],
+            'healthRetryAfterMillis' => $this->config['healthRetryAfterMillis'],
+        ]);
+
+        return new HttpClient([
+            'loadBalancer' => $loadBalancer,
+            'timeoutMillis' => $timeoutMillis,
+            'retryAttempts' => $retryAttempts,
+            'retryDelayMillis' => $retryDelayMillis,
+            'enableFailover' => $this->config['enableFailover'],
+            'bearerToken' => $bearerToken,
+            'headers' => $headers,
+        ]);
+    }
+
+    private function buildAck(array $msg, bool|string $status, array $context, bool $hasIndividualStatus): array
+    {
+        $transactionId = $msg['transactionId'] ?? $msg['id'] ?? null;
+        $partitionId = $msg['partitionId'] ?? null;
+        $leaseId = $msg['leaseId'] ?? null;
+
+        if ($transactionId === null) {
+            throw new \InvalidArgumentException('Message must have transactionId or id property');
+        }
+
+        if ($partitionId === null) {
+            throw new \InvalidArgumentException('Message must have partitionId property to ensure message uniqueness');
+        }
+
+        $msgStatus = $hasIndividualStatus && array_key_exists('_status', $msg)
+            ? $msg['_status']
+            : $status;
+
+        $statusStr = is_bool($msgStatus) ? ($msgStatus ? 'completed' : 'failed') : $msgStatus;
+
+        $ack = [
+            'transactionId' => $transactionId,
+            'partitionId' => $partitionId,
+            'status' => $statusStr,
+            'error' => $msg['_error'] ?? $context['error'] ?? null,
+        ];
+
+        if ($leaseId !== null) {
+            $ack['leaseId'] = $leaseId;
+        }
+
+        return $ack;
+    }
+}

--- a/client-laravel/src/Support/Defaults.php
+++ b/client-laravel/src/Support/Defaults.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Queen\Support;
+
+class Defaults
+{
+    public const CLIENT_DEFAULTS = [
+        'timeoutMillis' => 30000,
+        'retryAttempts' => 3,
+        'retryDelayMillis' => 1000,
+        'loadBalancingStrategy' => 'affinity',
+        'affinityHashRing' => 128,
+        'enableFailover' => true,
+        'healthRetryAfterMillis' => 5000,
+        'bearerToken' => null,
+        'headers' => [],
+    ];
+
+    public const QUEUE_DEFAULTS = [
+        'leaseTime' => 300,
+        'retryLimit' => 3,
+        'priority' => 0,
+        'delayedProcessing' => 0,
+        'windowBuffer' => 0,
+        'maxSize' => 0,
+        'retentionSeconds' => 0,
+        'completedRetentionSeconds' => 0,
+        'encryptionEnabled' => false,
+    ];
+
+    public const CONSUME_DEFAULTS = [
+        'concurrency' => 1,
+        'batch' => 1,
+        'autoAck' => true,
+        'wait' => true,
+        'timeoutMillis' => 30000,
+        'limit' => null,
+        'idleMillis' => null,
+        'renewLease' => false,
+        'renewLeaseIntervalMillis' => null,
+        'subscriptionMode' => null,
+        'subscriptionFrom' => null,
+    ];
+
+    public const POP_DEFAULTS = [
+        'batch' => 1,
+        'wait' => false,
+        'timeoutMillis' => 30000,
+        'autoAck' => false,
+    ];
+
+    public const BUFFER_DEFAULTS = [
+        'messageCount' => 100,
+        'timeMillis' => 1000,
+    ];
+}

--- a/client-laravel/src/Support/Uuid.php
+++ b/client-laravel/src/Support/Uuid.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Queen\Support;
+
+use Ramsey\Uuid\Uuid as RamseyUuid;
+
+class Uuid
+{
+    public static function v7(): string
+    {
+        return RamseyUuid::uuid7()->toString();
+    }
+}

--- a/client-laravel/tests/BufferManagerTest.php
+++ b/client-laravel/tests/BufferManagerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Queen\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Queen\Buffer\BufferManager;
+use Queen\Http\HttpClient;
+
+class BufferManagerTest extends TestCase
+{
+    public function testAddMessageCreatesBuffer(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $manager = new BufferManager($httpClient);
+
+        $stats = $manager->getStats();
+        $this->assertSame(0, $stats['activeBuffers']);
+
+        $manager->addMessage('queue/Default', ['payload' => 'test'], ['messageCount' => 100, 'timeMillis' => 1000]);
+
+        $stats = $manager->getStats();
+        $this->assertSame(1, $stats['activeBuffers']);
+        $this->assertSame(1, $stats['totalBufferedMessages']);
+    }
+
+    public function testFlushBufferSendsMessages(): void
+    {
+        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with('/api/v1/push', $this->callback(function (array $body) {
+                return count($body['items']) === 3;
+            }))
+            ->willReturn(['success' => true]);
+
+        $manager = new BufferManager($httpClient);
+
+        for ($i = 0; $i < 3; $i++) {
+            $manager->addMessage('queue/Default', ['payload' => "msg{$i}"], ['messageCount' => 100, 'timeMillis' => 99999]);
+        }
+
+        $manager->flushBuffer('queue/Default');
+
+        $stats = $manager->getStats();
+        $this->assertSame(0, $stats['activeBuffers']);
+        $this->assertSame(1, $stats['flushesPerformed']);
+    }
+
+    public function testFlushBufferRestoresOnFailure(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $httpClient->method('post')
+            ->willThrowException(new \RuntimeException('Server error'));
+
+        $manager = new BufferManager($httpClient);
+
+        $manager->addMessage('queue/Default', ['payload' => 'msg1'], ['messageCount' => 100, 'timeMillis' => 99999]);
+        $manager->addMessage('queue/Default', ['payload' => 'msg2'], ['messageCount' => 100, 'timeMillis' => 99999]);
+
+        try {
+            $manager->flushBuffer('queue/Default');
+            $this->fail('Should have thrown');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Server error', $e->getMessage());
+        }
+
+        // Messages should be restored
+        $stats = $manager->getStats();
+        $this->assertSame(2, $stats['totalBufferedMessages']);
+        $this->assertSame(0, $stats['flushesPerformed']);
+    }
+
+    public function testCleanupClearsAllBuffers(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $manager = new BufferManager($httpClient);
+
+        $manager->addMessage('q1/p1', ['payload' => 'a'], ['messageCount' => 100, 'timeMillis' => 99999]);
+        $manager->addMessage('q2/p1', ['payload' => 'b'], ['messageCount' => 100, 'timeMillis' => 99999]);
+
+        $stats = $manager->getStats();
+        $this->assertSame(2, $stats['activeBuffers']);
+
+        $manager->cleanup();
+
+        $stats = $manager->getStats();
+        $this->assertSame(0, $stats['activeBuffers']);
+        $this->assertSame(0, $stats['totalBufferedMessages']);
+    }
+
+    public function testFlushNonExistentBufferIsNoop(): void
+    {
+        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient->expects($this->never())->method('post');
+
+        $manager = new BufferManager($httpClient);
+        $manager->flushBuffer('nonexistent');
+
+        // Should not throw
+        $this->assertTrue(true);
+    }
+
+    public function testAutoFlushOnCountThreshold(): void
+    {
+        $httpClient = $this->createMock(HttpClient::class);
+        // The auto-flush from MessageBuffer triggers doFlush which calls post
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with('/api/v1/push', $this->callback(function (array $body) {
+                return count($body['items']) === 3;
+            }))
+            ->willReturn(['success' => true]);
+
+        $manager = new BufferManager($httpClient);
+
+        // messageCount=3, so adding 3 messages should trigger auto-flush
+        $manager->addMessage('queue/Default', ['payload' => 'msg1'], ['messageCount' => 3, 'timeMillis' => 99999]);
+        $manager->addMessage('queue/Default', ['payload' => 'msg2'], ['messageCount' => 3, 'timeMillis' => 99999]);
+        $manager->addMessage('queue/Default', ['payload' => 'msg3'], ['messageCount' => 3, 'timeMillis' => 99999]);
+    }
+
+    public function testMultipleBuffersTrackedSeparately(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $manager = new BufferManager($httpClient);
+
+        $manager->addMessage('q1/p1', ['payload' => 'a'], ['messageCount' => 100, 'timeMillis' => 99999]);
+        $manager->addMessage('q1/p1', ['payload' => 'b'], ['messageCount' => 100, 'timeMillis' => 99999]);
+        $manager->addMessage('q2/p1', ['payload' => 'c'], ['messageCount' => 100, 'timeMillis' => 99999]);
+
+        $stats = $manager->getStats();
+        $this->assertSame(2, $stats['activeBuffers']);
+        $this->assertSame(3, $stats['totalBufferedMessages']);
+    }
+}

--- a/client-laravel/tests/HighLevelConsumerTest.php
+++ b/client-laravel/tests/HighLevelConsumerTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Queen\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Queen\Consumer\HighLevelConsumer;
+use Queen\Http\HttpClient;
+use Queen\Queen;
+
+class HighLevelConsumerTest extends TestCase
+{
+    public function testConsumeWithoutSubscribeThrows(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $queen = $this->createStub(Queen::class);
+
+        $consumer = new HighLevelConsumer($httpClient, $queen, [
+            'queue' => 'test',
+            'group' => 'g1',
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('not subscribed');
+        $consumer->consume();
+    }
+
+    public function testConsumeReturnsMessageFromServer(): void
+    {
+        $httpClient = $this->createMock(HttpClient::class);
+        $queen = $this->createStub(Queen::class);
+
+        $httpClient->expects($this->once())
+            ->method('get')
+            ->willReturn([
+                'messages' => [
+                    ['transactionId' => 'tx-1', 'partitionId' => 'p1', 'payload' => ['data' => 1]],
+                ],
+            ]);
+
+        $consumer = new HighLevelConsumer($httpClient, $queen, [
+            'queue' => 'test',
+            'group' => 'g1',
+        ]);
+
+        $consumer->subscribe();
+        $msg = $consumer->consume(1000);
+
+        $this->assertNotNull($msg);
+        $this->assertSame('tx-1', $msg['transactionId']);
+        $this->assertArrayHasKey('trace', $msg);
+    }
+
+    public function testConsumeReturnsNullOnEmpty(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $queen = $this->createStub(Queen::class);
+
+        $httpClient->method('get')->willReturn(['messages' => []]);
+
+        $consumer = new HighLevelConsumer($httpClient, $queen, [
+            'queue' => 'test',
+            'group' => 'g1',
+        ]);
+
+        $consumer->subscribe();
+        $msg = $consumer->consume(100);
+
+        $this->assertNull($msg);
+    }
+
+    public function testConsumeReturnsNullOnTimeout(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $queen = $this->createStub(Queen::class);
+
+        $httpClient->method('get')->willThrowException(new \RuntimeException('cURL error 28: Operation timed out'));
+
+        $consumer = new HighLevelConsumer($httpClient, $queen, [
+            'queue' => 'test',
+            'group' => 'g1',
+        ]);
+
+        $consumer->subscribe();
+        $msg = $consumer->consume(100);
+
+        $this->assertNull($msg);
+    }
+
+    public function testAckDelegatesToQueen(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $queen = $this->createMock(Queen::class);
+
+        $message = ['transactionId' => 'tx-1', 'partitionId' => 'p1'];
+
+        $queen->expects($this->once())
+            ->method('ack')
+            ->with($message, true, ['group' => 'g1'])
+            ->willReturn(['success' => true]);
+
+        $consumer = new HighLevelConsumer($httpClient, $queen, [
+            'queue' => 'test',
+            'group' => 'g1',
+        ]);
+
+        $result = $consumer->ack($message);
+        $this->assertTrue($result['success']);
+    }
+
+    public function testNackDelegatesToQueen(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $queen = $this->createMock(Queen::class);
+
+        $message = ['transactionId' => 'tx-1', 'partitionId' => 'p1'];
+
+        $queen->expects($this->once())
+            ->method('ack')
+            ->with($message, false, ['group' => 'g1'])
+            ->willReturn(['success' => true]);
+
+        $consumer = new HighLevelConsumer($httpClient, $queen, [
+            'queue' => 'test',
+            'group' => 'g1',
+        ]);
+
+        $consumer->nack($message);
+    }
+
+    public function testCloseStopsConsuming(): void
+    {
+        $httpClient = $this->createMock(HttpClient::class);
+        $queen = $this->createStub(Queen::class);
+
+        // get() should never be called after close
+        $httpClient->expects($this->never())->method('get');
+
+        $consumer = new HighLevelConsumer($httpClient, $queen, [
+            'queue' => 'test',
+            'group' => 'g1',
+        ]);
+
+        $consumer->subscribe();
+        $consumer->close();
+
+        $this->assertTrue($consumer->isClosed());
+        $msg = $consumer->consume(100);
+        $this->assertNull($msg);
+    }
+
+    public function testConsumeBatchReturnsBatch(): void
+    {
+        $httpClient = $this->createMock(HttpClient::class);
+        $queen = $this->createStub(Queen::class);
+
+        $httpClient->expects($this->once())
+            ->method('get')
+            ->willReturn([
+                'messages' => [
+                    ['transactionId' => 'tx-1', 'partitionId' => 'p1', 'payload' => 1],
+                    ['transactionId' => 'tx-2', 'partitionId' => 'p2', 'payload' => 2],
+                    ['transactionId' => 'tx-3', 'partitionId' => 'p3', 'payload' => 3],
+                ],
+            ]);
+
+        $consumer = new HighLevelConsumer($httpClient, $queen, [
+            'queue' => 'test',
+            'group' => 'g1',
+        ]);
+
+        $consumer->subscribe();
+        $messages = $consumer->consumeBatch(1000, 10);
+
+        $this->assertCount(3, $messages);
+        $this->assertSame('tx-1', $messages[0]['transactionId']);
+        $this->assertSame('tx-3', $messages[2]['transactionId']);
+    }
+
+    public function testRenewLeaseDelegatesToQueen(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $queen = $this->createMock(Queen::class);
+
+        $queen->expects($this->once())
+            ->method('renew')
+            ->with('lease-123')
+            ->willReturn(['success' => true, 'leaseId' => 'lease-123']);
+
+        $consumer = new HighLevelConsumer($httpClient, $queen, [
+            'queue' => 'test',
+            'group' => 'g1',
+        ]);
+
+        $result = $consumer->renewLease('lease-123');
+        $this->assertTrue($result['success']);
+    }
+
+    public function testConsumeReturnsNullOnConnectionRefused(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $queen = $this->createStub(Queen::class);
+
+        $httpClient->method('get')->willThrowException(new \RuntimeException('Connection refused'));
+
+        $consumer = new HighLevelConsumer($httpClient, $queen, [
+            'queue' => 'test',
+            'group' => 'g1',
+        ]);
+
+        $consumer->subscribe();
+        $msg = $consumer->consume(100);
+
+        $this->assertNull($msg);
+    }
+
+    public function testConsumeThrowsOnUnexpectedError(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $queen = $this->createStub(Queen::class);
+
+        $httpClient->method('get')->willThrowException(new \RuntimeException('Unexpected error'));
+
+        $consumer = new HighLevelConsumer($httpClient, $queen, [
+            'queue' => 'test',
+            'group' => 'g1',
+        ]);
+
+        $consumer->subscribe();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Unexpected error');
+        $consumer->consume(100);
+    }
+}

--- a/client-laravel/tests/HttpClientTest.php
+++ b/client-laravel/tests/HttpClientTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Queen\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Queen\Http\HttpClient;
+use Queen\Http\LoadBalancer;
+use Queen\Exceptions\HttpException;
+
+class HttpClientTest extends TestCase
+{
+    public function testNoBaseUrlAndNoLoadBalancerThrows(): void
+    {
+        $client = new HttpClient([]);
+
+        $this->expectException(\LogicException::class);
+        $client->get('/test');
+    }
+
+    public function testHttpExceptionHasStatusCode(): void
+    {
+        $ex = new HttpException('Not Found', 404);
+
+        $this->assertSame(404, $ex->statusCode);
+        $this->assertSame('Not Found', $ex->getMessage());
+        $this->assertInstanceOf(\RuntimeException::class, $ex);
+    }
+
+    public function testHttpExceptionWithPrevious(): void
+    {
+        $previous = new \RuntimeException('original');
+        $ex = new HttpException('Wrapped', 500, 0, $previous);
+
+        $this->assertSame(500, $ex->statusCode);
+        $this->assertSame($previous, $ex->getPrevious());
+    }
+
+    public function testGetLoadBalancerReturnsNull(): void
+    {
+        $client = new HttpClient(['baseUrl' => 'http://localhost']);
+        $this->assertNull($client->getLoadBalancer());
+    }
+
+    public function testGetLoadBalancerReturnsInstance(): void
+    {
+        $lb = new LoadBalancer(['http://a', 'http://b']);
+        $client = new HttpClient(['loadBalancer' => $lb]);
+        $this->assertSame($lb, $client->getLoadBalancer());
+    }
+}

--- a/client-laravel/tests/LoadBalancerTest.php
+++ b/client-laravel/tests/LoadBalancerTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Queen\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Queen\Http\LoadBalancer;
+
+class LoadBalancerTest extends TestCase
+{
+    public function testRoundRobinCyclesThroughUrls(): void
+    {
+        $lb = new LoadBalancer(['http://a', 'http://b', 'http://c'], 'round-robin');
+
+        $results = [];
+        for ($i = 0; $i < 6; $i++) {
+            $results[] = $lb->getNextUrl();
+        }
+
+        $this->assertSame('http://a', $results[0]);
+        $this->assertSame('http://b', $results[1]);
+        $this->assertSame('http://c', $results[2]);
+        $this->assertSame('http://a', $results[3]);
+        $this->assertSame('http://b', $results[4]);
+        $this->assertSame('http://c', $results[5]);
+    }
+
+    public function testAffinityReturnsSameServerForSameKey(): void
+    {
+        $lb = new LoadBalancer(
+            ['http://a', 'http://b', 'http://c'],
+            'affinity',
+            ['affinityHashRing' => 150]
+        );
+
+        $url1 = $lb->getNextUrl('user-123');
+        $url2 = $lb->getNextUrl('user-123');
+        $url3 = $lb->getNextUrl('user-123');
+
+        $this->assertSame($url1, $url2);
+        $this->assertSame($url2, $url3);
+    }
+
+    public function testAffinityDistributesDifferentKeys(): void
+    {
+        $lb = new LoadBalancer(
+            ['http://a', 'http://b', 'http://c'],
+            'affinity',
+            ['affinityHashRing' => 150]
+        );
+
+        $servers = [];
+        for ($i = 0; $i < 100; $i++) {
+            $url = $lb->getNextUrl("key-{$i}");
+            $servers[$url] = ($servers[$url] ?? 0) + 1;
+        }
+
+        // All three servers should get some traffic
+        $this->assertCount(3, $servers, 'Affinity should distribute across all servers');
+    }
+
+    public function testMarkUnhealthySkipsServer(): void
+    {
+        $lb = new LoadBalancer(['http://a', 'http://b'], 'round-robin');
+
+        $lb->markUnhealthy('http://a');
+
+        // All requests should go to http://b
+        for ($i = 0; $i < 5; $i++) {
+            $this->assertSame('http://b', $lb->getNextUrl());
+        }
+    }
+
+    public function testMarkHealthyRestoresServer(): void
+    {
+        $lb = new LoadBalancer(['http://a', 'http://b'], 'round-robin');
+
+        $lb->markUnhealthy('http://a');
+        $this->assertSame('http://b', $lb->getNextUrl());
+
+        $lb->markHealthy('http://a');
+
+        // Both servers should be used again
+        $urls = [];
+        for ($i = 0; $i < 4; $i++) {
+            $urls[] = $lb->getNextUrl();
+        }
+        $this->assertContains('http://a', $urls);
+        $this->assertContains('http://b', $urls);
+    }
+
+    public function testAllUnhealthyFallsBackToAnyServer(): void
+    {
+        $lb = new LoadBalancer(['http://a', 'http://b'], 'round-robin');
+
+        $lb->markUnhealthy('http://a');
+        $lb->markUnhealthy('http://b');
+
+        // Should still return something rather than crash
+        $url = $lb->getNextUrl();
+        $this->assertContains($url, ['http://a', 'http://b']);
+    }
+
+    public function testFnvHashConsistency(): void
+    {
+        // Same inputs should always produce same routing
+        $lb = new LoadBalancer(['http://a', 'http://b', 'http://c'], 'affinity');
+
+        $mapping = [];
+        for ($i = 0; $i < 50; $i++) {
+            $mapping["key-{$i}"] = $lb->getNextUrl("key-{$i}");
+        }
+
+        // Second pass should match exactly
+        foreach ($mapping as $key => $expectedUrl) {
+            $this->assertSame($expectedUrl, $lb->getNextUrl($key), "Affinity broken for {$key}");
+        }
+    }
+
+    public function testAffinityReroutesWhenServerUnhealthy(): void
+    {
+        $lb = new LoadBalancer(['http://a', 'http://b', 'http://c'], 'affinity');
+
+        $url = $lb->getNextUrl('test-key');
+        $lb->markUnhealthy($url);
+
+        $newUrl = $lb->getNextUrl('test-key');
+        $this->assertNotSame($url, $newUrl, 'Should route to different server after marking unhealthy');
+    }
+
+    public function testSessionStickyRouting(): void
+    {
+        $lb = new LoadBalancer(['http://a', 'http://b', 'http://c'], 'session');
+
+        $url = $lb->getNextUrl('session-1');
+
+        // Same session key should always go to same server
+        for ($i = 0; $i < 5; $i++) {
+            $this->assertSame($url, $lb->getNextUrl('session-1'));
+        }
+    }
+
+    public function testTrailingSlashesStripped(): void
+    {
+        $lb = new LoadBalancer(['http://a/', 'http://b/'], 'round-robin');
+
+        $urls = $lb->getAllUrls();
+        $this->assertSame('http://a', $urls[0]);
+        $this->assertSame('http://b', $urls[1]);
+    }
+
+    public function testHealthStatusTracking(): void
+    {
+        $lb = new LoadBalancer(['http://a', 'http://b'], 'round-robin');
+
+        $status = $lb->getHealthStatus();
+        $this->assertTrue($status['http://a']['healthy']);
+        $this->assertTrue($status['http://b']['healthy']);
+        $this->assertSame(0, $status['http://a']['failures']);
+
+        $lb->markUnhealthy('http://a');
+        $status = $lb->getHealthStatus();
+        $this->assertFalse($status['http://a']['healthy']);
+        $this->assertSame(1, $status['http://a']['failures']);
+        $this->assertNotNull($status['http://a']['lastFailure']);
+    }
+}

--- a/client-laravel/tests/MessageBufferTest.php
+++ b/client-laravel/tests/MessageBufferTest.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Queen\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Queen\Buffer\MessageBuffer;
+
+class MessageBufferTest extends TestCase
+{
+    private array $flushedAddresses = [];
+
+    private function makeBuffer(int $messageCount = 5, int $timeMillis = 1000): MessageBuffer
+    {
+        $this->flushedAddresses = [];
+
+        return new MessageBuffer('test-queue/Default', [
+            'messageCount' => $messageCount,
+            'timeMillis' => $timeMillis,
+        ], function (string $addr) {
+            $this->flushedAddresses[] = $addr;
+        });
+    }
+
+    public function testAddAndExtractMessages(): void
+    {
+        $buffer = $this->makeBuffer();
+
+        $buffer->add(['payload' => 'msg1']);
+        $buffer->add(['payload' => 'msg2']);
+        $buffer->add(['payload' => 'msg3']);
+
+        $this->assertSame(3, $buffer->getMessageCount());
+
+        $messages = $buffer->extractMessages();
+        $this->assertCount(3, $messages);
+        $this->assertSame(0, $buffer->getMessageCount());
+    }
+
+    public function testExtractWithBatchSize(): void
+    {
+        $buffer = $this->makeBuffer();
+
+        for ($i = 0; $i < 5; $i++) {
+            $buffer->add(['payload' => "msg{$i}"]);
+        }
+
+        $batch1 = $buffer->extractMessages(2);
+        $this->assertCount(2, $batch1);
+        $this->assertSame(3, $buffer->getMessageCount());
+
+        $batch2 = $buffer->extractMessages(2);
+        $this->assertCount(2, $batch2);
+        $this->assertSame(1, $buffer->getMessageCount());
+
+        $batch3 = $buffer->extractMessages(2);
+        $this->assertCount(1, $batch3);
+        $this->assertSame(0, $buffer->getMessageCount());
+    }
+
+    public function testCountTriggerCallsFlush(): void
+    {
+        $buffer = $this->makeBuffer(3, 99999);
+
+        $buffer->add(['payload' => 'msg1']);
+        $buffer->add(['payload' => 'msg2']);
+        $this->assertEmpty($this->flushedAddresses);
+
+        $buffer->add(['payload' => 'msg3']); // Hits threshold of 3
+        $this->assertCount(1, $this->flushedAddresses);
+        $this->assertSame('test-queue/Default', $this->flushedAddresses[0]);
+    }
+
+    public function testRestoreMessagesPutsThemBack(): void
+    {
+        $buffer = $this->makeBuffer();
+
+        $buffer->add(['payload' => 'msg1']);
+        $buffer->add(['payload' => 'msg2']);
+
+        $extracted = $buffer->extractMessages();
+        $this->assertSame(0, $buffer->getMessageCount());
+
+        $buffer->restoreMessages($extracted);
+        $this->assertSame(2, $buffer->getMessageCount());
+
+        // Messages should be in original order
+        $restored = $buffer->extractMessages();
+        $this->assertSame('msg1', $restored[0]['payload']);
+        $this->assertSame('msg2', $restored[1]['payload']);
+    }
+
+    public function testRestorePrependsToExisting(): void
+    {
+        $buffer = $this->makeBuffer(100); // High threshold so no auto-flush
+
+        $buffer->add(['payload' => 'existing1']);
+        $buffer->add(['payload' => 'existing2']);
+
+        $buffer->restoreMessages([['payload' => 'restored1'], ['payload' => 'restored2']]);
+
+        $all = $buffer->extractMessages();
+        $this->assertCount(4, $all);
+        $this->assertSame('restored1', $all[0]['payload']);
+        $this->assertSame('restored2', $all[1]['payload']);
+        $this->assertSame('existing1', $all[2]['payload']);
+        $this->assertSame('existing2', $all[3]['payload']);
+    }
+
+    public function testCleanupResetsState(): void
+    {
+        $buffer = $this->makeBuffer();
+
+        $buffer->add(['payload' => 'msg1']);
+        $buffer->add(['payload' => 'msg2']);
+        $this->assertSame(2, $buffer->getMessageCount());
+
+        $buffer->cleanup();
+        $this->assertSame(0, $buffer->getMessageCount());
+        $this->assertSame(0.0, $buffer->getFirstMessageAge());
+    }
+
+    public function testFirstMessageAgeTracking(): void
+    {
+        $buffer = $this->makeBuffer();
+
+        $this->assertSame(0.0, $buffer->getFirstMessageAge());
+
+        $buffer->add(['payload' => 'msg1']);
+        usleep(10_000); // 10ms
+        $age = $buffer->getFirstMessageAge();
+        $this->assertGreaterThan(5, $age); // At least 5ms
+    }
+
+    public function testFlushingFlagPreventsDoubleTrigger(): void
+    {
+        $buffer = $this->makeBuffer(2, 99999);
+
+        $buffer->add(['payload' => 'msg1']);
+        $buffer->add(['payload' => 'msg2']); // Triggers flush, sets flushing=true
+
+        // Now the buffer is in "flushing" state.
+        // Adding more should NOT trigger again because flushing=true
+        $buffer->add(['payload' => 'msg3']);
+        $buffer->add(['payload' => 'msg4']);
+
+        // Only one flush call
+        $this->assertCount(1, $this->flushedAddresses);
+    }
+
+    public function testExtractResetsFlushingFlag(): void
+    {
+        $buffer = $this->makeBuffer(2, 99999);
+
+        $buffer->add(['payload' => 'msg1']);
+        $buffer->add(['payload' => 'msg2']); // Triggers flush
+
+        // Extract clears the flushing flag
+        $buffer->extractMessages();
+
+        // Now adding should trigger flush again
+        $buffer->add(['payload' => 'msg3']);
+        $buffer->add(['payload' => 'msg4']); // Should trigger
+
+        $this->assertCount(2, $this->flushedAddresses);
+    }
+
+    public function testGetOptions(): void
+    {
+        $buffer = $this->makeBuffer(42, 5000);
+        $options = $buffer->getOptions();
+        $this->assertSame(42, $options['messageCount']);
+        $this->assertSame(5000, $options['timeMillis']);
+    }
+}

--- a/client-laravel/tests/QueenConfigTest.php
+++ b/client-laravel/tests/QueenConfigTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Queen\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Queen\Queen;
+use Queen\Support\Defaults;
+
+class QueenConfigTest extends TestCase
+{
+    public function testConstructWithSingleUrl(): void
+    {
+        $queen = new Queen('http://localhost:6632');
+
+        // Should be able to create queue builders
+        $builder = $queen->queue('test');
+        $this->assertInstanceOf(\Queen\Builders\QueueBuilder::class, $builder);
+    }
+
+    public function testConstructWithUrlArray(): void
+    {
+        $queen = new Queen(['http://a:6632', 'http://b:6632']);
+        $builder = $queen->queue('test');
+        $this->assertInstanceOf(\Queen\Builders\QueueBuilder::class, $builder);
+    }
+
+    public function testConstructWithConfigArray(): void
+    {
+        $queen = new Queen([
+            'urls' => ['http://a:6632', 'http://b:6632'],
+            'bearerToken' => 'test-token',
+            'timeoutMillis' => 5000,
+            'loadBalancingStrategy' => 'round-robin',
+        ]);
+
+        $builder = $queen->queue('test');
+        $this->assertInstanceOf(\Queen\Builders\QueueBuilder::class, $builder);
+    }
+
+    public function testConstructWithSingleUrlConfig(): void
+    {
+        $queen = new Queen([
+            'url' => 'http://localhost:6632',
+        ]);
+
+        $builder = $queen->queue('test');
+        $this->assertInstanceOf(\Queen\Builders\QueueBuilder::class, $builder);
+    }
+
+    public function testConstructWithNoUrlThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Must provide urls or url');
+
+        new Queen(['bearerToken' => 'test']);
+    }
+
+    public function testAdminIsSingleton(): void
+    {
+        $queen = new Queen('http://localhost:6632');
+
+        $admin1 = $queen->admin();
+        $admin2 = $queen->admin();
+
+        $this->assertSame($admin1, $admin2);
+    }
+
+    public function testTransactionBuilderCreated(): void
+    {
+        $queen = new Queen('http://localhost:6632');
+        $tx = $queen->transaction();
+        $this->assertInstanceOf(\Queen\Builders\TransactionBuilder::class, $tx);
+    }
+
+    public function testBufferStatsInitiallyEmpty(): void
+    {
+        $queen = new Queen('http://localhost:6632');
+        $stats = $queen->getBufferStats();
+
+        $this->assertSame(0, $stats['activeBuffers']);
+        $this->assertSame(0, $stats['totalBufferedMessages']);
+        $this->assertSame(0, $stats['flushesPerformed']);
+    }
+
+    public function testCloseDoesNotThrow(): void
+    {
+        $queen = new Queen('http://localhost:6632');
+        $queen->close();
+
+        // Should be safe to call close even with no active buffers
+        $this->assertTrue(true);
+    }
+}

--- a/client-laravel/tests/QueueBuilderTest.php
+++ b/client-laravel/tests/QueueBuilderTest.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Queen\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Queen\Queen;
+use Queen\Builders\QueueBuilder;
+use Queen\Builders\ConsumeBuilder;
+use Queen\Builders\OperationBuilder;
+use Queen\Builders\PushBuilder;
+use Queen\Builders\DLQBuilder;
+use Queen\Consumer\HighLevelConsumer;
+
+class QueueBuilderTest extends TestCase
+{
+    private Queen $queen;
+
+    protected function setUp(): void
+    {
+        $this->queen = new Queen('http://localhost:6632');
+    }
+
+    public function testFluentChaining(): void
+    {
+        $builder = $this->queen->queue('orders');
+
+        $result = $builder
+            ->namespace('shop')
+            ->task('process')
+            ->partition('user-1')
+            ->group('processors')
+            ->concurrency(4)
+            ->batch(10)
+            ->limit(1000)
+            ->idleMillis(5000)
+            ->autoAck(false)
+            ->wait(true)
+            ->timeoutMillis(60000)
+            ->renewLease(true, 30000)
+            ->subscriptionMode('all')
+            ->subscriptionFrom('2024-01-01T00:00:00Z');
+
+        // All methods should return the same builder (fluent)
+        $this->assertSame($builder, $result);
+    }
+
+    public function testCreateReturnsOperationBuilder(): void
+    {
+        $op = $this->queen->queue('test-queue')
+            ->config(['leaseTime' => 600])
+            ->create();
+
+        $this->assertInstanceOf(OperationBuilder::class, $op);
+    }
+
+    public function testDeleteReturnsOperationBuilder(): void
+    {
+        $op = $this->queen->queue('test-queue')->delete();
+        $this->assertInstanceOf(OperationBuilder::class, $op);
+    }
+
+    public function testDeleteWithoutQueueNameThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->queen->queue()->delete();
+    }
+
+    public function testPushReturnsPushBuilder(): void
+    {
+        $push = $this->queen->queue('test-queue')->push([
+            ['data' => ['key' => 'value']],
+        ]);
+
+        $this->assertInstanceOf(PushBuilder::class, $push);
+    }
+
+    public function testPushWithoutQueueNameThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->queen->queue()->push([['data' => 'test']]);
+    }
+
+    public function testConsumeReturnsConsumeBuilder(): void
+    {
+        $consume = $this->queen->queue('test-queue')
+            ->group('my-group')
+            ->consume(function ($messages) {});
+
+        $this->assertInstanceOf(ConsumeBuilder::class, $consume);
+    }
+
+    public function testGetConsumerReturnsHighLevelConsumer(): void
+    {
+        $consumer = $this->queen->queue('test-queue')
+            ->group('my-group')
+            ->batch(5)
+            ->getConsumer();
+
+        $this->assertInstanceOf(HighLevelConsumer::class, $consumer);
+    }
+
+    public function testDlqReturnsDLQBuilder(): void
+    {
+        $dlq = $this->queen->queue('test-queue')->dlq('my-group');
+        $this->assertInstanceOf(DLQBuilder::class, $dlq);
+    }
+
+    public function testDlqWithoutQueueNameThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->queen->queue()->dlq();
+    }
+
+    public function testFlushBufferWithoutQueueNameThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->queen->queue()->flushBuffer();
+    }
+
+    public function testEachMethodSetsFlag(): void
+    {
+        // each() should be chainable and return the builder
+        $builder = $this->queen->queue('test');
+        $result = $builder->each();
+        $this->assertSame($builder, $result);
+    }
+
+    public function testBufferMethodSetsOptions(): void
+    {
+        $builder = $this->queen->queue('test');
+        $result = $builder->buffer(['messageCount' => 50, 'timeMillis' => 500]);
+        $this->assertSame($builder, $result);
+    }
+
+    public function testConcurrencyMinimumIsOne(): void
+    {
+        $builder = $this->queen->queue('test');
+        $result = $builder->concurrency(0);
+        $this->assertSame($builder, $result);
+        // concurrency(0) should be clamped to 1 internally
+    }
+
+    public function testBatchMinimumIsOne(): void
+    {
+        $builder = $this->queen->queue('test');
+        $result = $builder->batch(0);
+        $this->assertSame($builder, $result);
+    }
+}

--- a/client-laravel/tests/TransactionBuilderTest.php
+++ b/client-laravel/tests/TransactionBuilderTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Queen\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Queen\Builders\TransactionBuilder;
+use Queen\Http\HttpClient;
+
+class TransactionBuilderTest extends TestCase
+{
+    public function testCommitWithNoOperationsThrows(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $tx = new TransactionBuilder($httpClient);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Transaction has no operations');
+        $tx->commit();
+    }
+
+    public function testAckWithoutTransactionIdThrows(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $tx = new TransactionBuilder($httpClient);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('transactionId');
+        $tx->ack([['partitionId' => 'p1']]);
+    }
+
+    public function testAckWithoutPartitionIdThrows(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $tx = new TransactionBuilder($httpClient);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('partitionId');
+        $tx->ack([['transactionId' => 'tx-1']]);
+    }
+
+    public function testAckAndPushBuildOperations(): void
+    {
+        $httpClient = $this->createMock(HttpClient::class);
+
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                '/api/v1/transaction',
+                $this->callback(function (array $body) {
+                    // Should have 2 operations: 1 ack + 1 push
+                    $this->assertCount(2, $body['operations']);
+                    $this->assertSame('ack', $body['operations'][0]['type']);
+                    $this->assertSame('tx-1', $body['operations'][0]['transactionId']);
+                    $this->assertSame('p1', $body['operations'][0]['partitionId']);
+                    $this->assertSame('completed', $body['operations'][0]['status']);
+                    $this->assertSame('push', $body['operations'][1]['type']);
+                    $this->assertCount(1, $body['operations'][1]['items']);
+                    return true;
+                })
+            )
+            ->willReturn(['success' => true, 'transactionId' => 'abc']);
+
+        $tx = new TransactionBuilder($httpClient);
+
+        $result = $tx
+            ->ack([['transactionId' => 'tx-1', 'partitionId' => 'p1', 'leaseId' => 'lease-1']])
+            ->queue('notifications')->push([['data' => ['notify' => true]]])
+            ->commit();
+
+        $this->assertTrue($result['success']);
+    }
+
+    public function testCommitFailureIncludesTransactionId(): void
+    {
+        $httpClient = $this->createStub(HttpClient::class);
+        $httpClient->method('post')->willReturn([
+            'success' => false,
+            'error' => 'conflict',
+            'transactionId' => 'tx-abc',
+        ]);
+
+        $tx = new TransactionBuilder($httpClient);
+        $tx->ack([['transactionId' => 'tx-1', 'partitionId' => 'p1']]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('tx-abc');
+        $tx->commit();
+    }
+
+    public function testQueueWithPartition(): void
+    {
+        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                '/api/v1/transaction',
+                $this->callback(function (array $body) {
+                    $pushOp = $body['operations'][0];
+                    $this->assertSame('push', $pushOp['type']);
+                    $this->assertSame('user-123', $pushOp['items'][0]['partition']);
+                    return true;
+                })
+            )
+            ->willReturn(['success' => true]);
+
+        $tx = new TransactionBuilder($httpClient);
+        $tx->queue('orders')->partition('user-123')->push([['data' => ['test' => 1]]]);
+        $tx->commit();
+    }
+
+    public function testLeaseIdsCollected(): void
+    {
+        $httpClient = $this->createMock(HttpClient::class);
+        $httpClient->expects($this->once())
+            ->method('post')
+            ->with(
+                '/api/v1/transaction',
+                $this->callback(function (array $body) {
+                    $this->assertContains('lease-1', $body['requiredLeases']);
+                    $this->assertContains('lease-2', $body['requiredLeases']);
+                    // Should deduplicate
+                    $this->assertCount(2, $body['requiredLeases']);
+                    return true;
+                })
+            )
+            ->willReturn(['success' => true]);
+
+        $tx = new TransactionBuilder($httpClient);
+        $tx->ack([
+            ['transactionId' => 'tx-1', 'partitionId' => 'p1', 'leaseId' => 'lease-1'],
+            ['transactionId' => 'tx-2', 'partitionId' => 'p2', 'leaseId' => 'lease-2'],
+            ['transactionId' => 'tx-3', 'partitionId' => 'p3', 'leaseId' => 'lease-1'], // duplicate
+        ]);
+        $tx->commit();
+    }
+}


### PR DESCRIPTION
Full-featured PHP 8.3+ client mirroring the JS client API with:
- Fluent builder pattern (queue/push/consume/transaction/DLQ)
- HTTP transport with retry, failover, and load balancing (round-robin/session/affinity)
- FNV-1a consistent hashing for affinity routing
- Client-side message buffering with count/time triggers and restore on failure
- Callback-based consumer (ConsumerManager) and rdkafka-style HighLevelConsumer
- Guzzle async for concurrent consumers and parallel buffer flush
- Admin API (30+ endpoints)
- Laravel integration (service provider, facade, artisan command)
- 75 unit tests covering all critical paths